### PR TITLE
U1: Add ZFS module skeleton with full D-Bus XML and polkit policy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -387,6 +387,32 @@ if test "x$enable_btrfs" = "xyes" \
 fi
 AM_CONDITIONAL(HAVE_BTRFS, [test "x$have_btrfs" = "xyes"])
 
+# ZFS module
+have_zfs=no
+AC_ARG_ENABLE(zfs, AS_HELP_STRING([--enable-zfs], [enable ZFS support]))
+if test "x$enable_zfs" = "xyes" \
+     -o "x$enable_modules" = "xyes" \
+     -o "x$enable_available_modules" = "xyes"; then
+    SAVE_CFLAGS=$CFLAGS
+    SAVE_LDFLAGS=$LDFLAGS
+    CFLAGS="$GLIB_CFLAGS"
+    LDFLAGS="$GLIB_LIBS"
+    AC_MSG_CHECKING(["libblockdev-zfs presence"])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <blockdev/zfs.h>]], [[]])],[AC_MSG_RESULT([yes])
+                    AC_DEFINE(HAVE_ZFS, 1, [Define, if libblockdev-zfs is available])
+                    have_zfs=yes],[AC_MSG_RESULT([no])
+                    have_zfs=no])
+    CFLAGS=$SAVE_CFLAGS
+    LDFLAGS=$SAVE_LDFLAGS
+
+    if test "x$have_zfs" = "xno"; then
+     if test "x$enable_zfs" = "xyes" -o "x$enable_modules" = "xyes"; then
+         AC_MSG_ERROR([ZFS support requested but header or library not found])
+     fi
+    fi
+fi
+AM_CONDITIONAL(HAVE_ZFS, [test "x$have_zfs" = "xyes"])
+
 # LSM module
 have_lsm=no
 have_libconfig=no
@@ -627,6 +653,9 @@ modules/lvm2/data/udisks2-lvm2.pc
 modules/lsm/Makefile
 modules/lsm/data/Makefile
 modules/lsm/data/udisks2-lsm.pc
+modules/zfs/Makefile
+modules/zfs/data/Makefile
+modules/zfs/data/udisks2-zfs.pc
 doc/Makefile
 doc/udisks2-docs.xml.in
 doc/udisks2-sections.txt.in
@@ -703,5 +732,6 @@ echo "
         BTRFS module:               ${have_btrfs}
         iSCSI module:               ${have_iscsi}${have_libiscsi_session_info_msg}
         LVM2  module:               ${have_lvm2}
+        ZFS module:                 ${have_zfs}
         LibStorageMgmt module:      ${have_lsm}
 "

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -18,4 +18,8 @@ if HAVE_LSM
 SUBDIRS += lsm
 endif # HAVE_LSM
 
+if HAVE_ZFS
+SUBDIRS += zfs
+endif # HAVE_ZFS
+
 NULL =

--- a/modules/zfs/Makefile.am
+++ b/modules/zfs/Makefile.am
@@ -1,0 +1,97 @@
+## Process this file with automake to produce Makefile.in
+
+SUBDIRS = data
+
+NULL =
+
+AM_CPPFLAGS =                                                                  \
+	-I$(top_builddir) -I$(top_srcdir)                                      \
+	-DPACKAGE_LIBEXEC_DIR=\""$(libexecdir)"\"                              \
+	-DPACKAGE_SYSCONF_DIR=\""$(sysconfdir)"\"                              \
+	-DPACKAGE_DATA_DIR=\""$(datadir)"\"                                    \
+	-DPACKAGE_BIN_DIR=\""$(bindir)"\"                                      \
+	-DPACKAGE_LOCALSTATE_DIR=\""$(localstatedir)"\"                        \
+	-DPACKAGE_LOCALE_DIR=\""$(localedir)"\"                                \
+	-DPACKAGE_LIB_DIR=\""$(libdir)"\"                                      \
+	-D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT                                \
+	-DUDISKS_COMPILATION                                                   \
+	$(POLKIT_GOBJECT_1_CFLAGS)                                             \
+	$(GLIB_CFLAGS)                                                         \
+	$(GIO_CFLAGS)                                                          \
+	$(GUDEV_CFLAGS)                                                        \
+	$(BLOCKDEV_CFLAGS)                                                     \
+	$(WARN_CFLAGS)                                                         \
+	$(NULL)
+
+if ENABLE_DAEMON
+
+ZFS_MODULE_DIR = $(top_srcdir)/modules/zfs
+
+MODULE_SO = libudisks2_zfs.so
+
+BUILT_SOURCES =                                                                \
+	$(NULL)
+
+libudisks2_zfsdir = $(libdir)/udisks2/modules
+libudisks2_zfs_LTLIBRARIES = libudisks2_zfs.la
+
+libudisks2_zfsincludedir = $(includedir)/udisks2/udisks
+
+libudisks2_zfs_la_SOURCES =                                                    \
+	$(BUILT_SOURCES)                                                       \
+	udiskslinuxmodulezfs.h                                                 \
+	udiskslinuxmodulezfs.c                                                 \
+	udiskslinuxmanagerzfs.h                                                \
+	udiskslinuxmanagerzfs.c                                                \
+	udiskszfstypes.h                                                       \
+	$(NULL)
+
+libudisks2_zfs_la_CPPFLAGS =                                                   \
+	$(AM_CPPFLAGS)                                                         \
+	-DG_LOG_DOMAIN=\"libudisks2-zfs\"                                      \
+	$(NULL)
+
+libudisks2_zfs_la_CFLAGS =                                                     \
+	$(GLIB_CFLAGS)                                                         \
+	$(GIO_CFLAGS)                                                          \
+	$(GUDEV_CFLAGS)                                                        \
+	$(POLKIT_GOBJECT_1_CFLAGS)                                             \
+	$(BLOCKDEV_CFLAGS)                                                     \
+	$(NULL)
+
+libudisks2_zfs_la_LDFLAGS =                                                    \
+	-export-dynamic                                                        \
+	-avoid-version                                                         \
+	-module                                                                \
+	-no-undefined                                                          \
+	-export-symbols-regex                                                  \
+	 '^udisks_.*|g_io_module_load|g_io_module_unload|g_io_module_query'    \
+	$(NULL)
+
+libudisks2_zfs_la_LIBADD =                                                     \
+	$(top_builddir)/src/libudisks-daemon.la                                \
+	$(GLIB_LIBS)                                                           \
+	$(GIO_LIBS)                                                            \
+	$(GUDEV_LIBS)                                                          \
+	$(POLKIT_GOBJECT_1_LIBS)                                               \
+	$(BLOCKDEV_LIBS)                                                       \
+	$(NULL)
+
+all-local: module_link
+
+endif # ENABLE_DAEMON
+
+# ------------------------------------------------------------------------------
+
+CLEANFILES =
+
+EXTRA_DIST =                                                                   \
+	$(NULL)
+
+include ../Makefile.uninstalled
+
+dist-hook:
+	(for i in $(BUILT_SOURCES); do rm -f $(distdir)/$$i; done)
+
+clean-local: module_unlink
+	rm -f *~ $(BUILT_SOURCES)

--- a/modules/zfs/data/Makefile.am
+++ b/modules/zfs/data/Makefile.am
@@ -1,0 +1,27 @@
+
+NULL =
+
+polkit_in_files  = org.freedesktop.UDisks2.zfs.policy.in
+
+if ENABLE_DAEMON
+
+polkitdir        = $(datadir)/polkit-1/actions
+polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
+
+$(polkit_DATA): $(polkit_in_files)
+	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
+
+endif # ENABLE_DAEMON
+
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = udisks2-zfs.pc
+
+EXTRA_DIST =                                                                   \
+	org.freedesktop.UDisks2.zfs.xml                                        \
+	udisks2-zfs.pc.in                                                      \
+	$(polkit_in_files)                                                     \
+	$(NULL)
+
+clean-local:
+	rm -f *~ $(polkit_DATA)

--- a/modules/zfs/data/org.freedesktop.UDisks2.zfs.policy.in
+++ b/modules/zfs/data/org.freedesktop.UDisks2.zfs.policy.in
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+
+<policyconfig>
+  <vendor>The Udisks Project</vendor>
+  <vendor_url>https://github.com/storaged-project/udisks</vendor_url>
+  <icon_name>drive-removable-media</icon_name>
+
+  <!-- ###################################################################### -->
+  <!-- Query ZFS status -->
+
+  <action id="org.freedesktop.udisks2.zfs.query">
+    <description>Query ZFS status</description>
+    <message>Authentication is required to query ZFS status</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <!-- ###################################################################### -->
+  <!-- Manage ZFS -->
+
+  <action id="org.freedesktop.udisks2.zfs.manage-zfs">
+    <description>Manage ZFS</description>
+    <message>Authentication is required to manage ZFS</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
+  <!-- ###################################################################### -->
+  <!-- Destroy ZFS resources -->
+
+  <action id="org.freedesktop.udisks2.zfs.manage-zfs-destroy">
+    <description>Destroy ZFS resources</description>
+    <message>Authentication is required to destroy ZFS resources</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+</policyconfig>

--- a/modules/zfs/data/org.freedesktop.UDisks2.zfs.xml
+++ b/modules/zfs/data/org.freedesktop.UDisks2.zfs.xml
@@ -1,0 +1,476 @@
+<!DOCTYPE node PUBLIC
+"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+
+<!--
+ Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General
+ Public License along with this library; if not, write to the
+ Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ Boston, MA 02111-1307, USA.
+-->
+
+  <!-- ********************************************************************** -->
+
+  <!--
+      org.freedesktop.UDisks2.Manager.ZFS:
+      @short_description: ZFS add-on to the manager singleton
+
+      Additional interface with ZFS specifics for top-level manager
+      singleton object located at the object path
+      <literal>/org/freedesktop/UDisks2/Manager</literal>.
+  -->
+  <interface name="org.freedesktop.UDisks2.Manager.ZFS">
+    <!-- prereq: org.freedesktop.UDisks2.Manager -->
+
+    <!--
+        PoolCreate:
+        @name: The name for the new pool.
+        @blocks: An array of object paths to objects implementing the #org.freedesktop.UDisks2.Block interface.
+        @vdev_type: The vdev type (e.g. "mirror", "raidz", "raidz2", "raidz3", or empty for stripe).
+        @options: Additional options.
+        @result: Object path of the new pool object.
+
+        Creates a new ZFS pool from @blocks.
+    -->
+    <method name="PoolCreate">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="blocks" direction="in" type="ao"/>
+      <arg name="vdev_type" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="result" direction="out" type="o"/>
+    </method>
+
+    <!--
+        PoolImport:
+        @name_or_guid: The pool name or GUID to import.
+        @options: Additional options.
+        @result: Object path of the imported pool object.
+
+        Imports a ZFS pool by name or GUID.
+    -->
+    <method name="PoolImport">
+      <arg name="name_or_guid" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="result" direction="out" type="o"/>
+    </method>
+
+    <!--
+        PoolImportAll:
+        @options: Additional options.
+
+        Imports all available ZFS pools.
+    -->
+    <method name="PoolImportAll">
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+  </interface>
+
+  <!-- ********************************************************************** -->
+
+  <!--
+      org.freedesktop.UDisks2.ZFSPool:
+      @short_description: ZFS pool interface
+
+      This interface is used for objects representing ZFS pools.
+  -->
+  <interface name="org.freedesktop.UDisks2.ZFSPool">
+
+    <property name="Name" type="s" access="read"/>
+    <property name="GUID" type="s" access="read"/>
+    <property name="State" type="s" access="read"/>
+    <property name="Size" type="t" access="read"/>
+    <property name="Allocated" type="t" access="read"/>
+    <property name="Free" type="t" access="read"/>
+    <property name="Fragmentation" type="t" access="read"/>
+    <property name="DedupRatio" type="d" access="read"/>
+    <property name="ReadOnly" type="b" access="read"/>
+    <property name="Altroot" type="s" access="read"/>
+    <property name="Health" type="s" access="read"/>
+    <property name="FeatureFlags" type="as" access="read"/>
+    <property name="ScrubRunning" type="b" access="read"/>
+    <property name="ScrubPaused" type="b" access="read"/>
+    <property name="ScrubProgress" type="d" access="read"/>
+    <property name="ScrubErrors" type="t" access="read"/>
+
+    <!--
+        Poll:
+
+        Re-reads pool status from the kernel.
+    -->
+    <method name="Poll"/>
+
+    <!--
+        Export:
+        @force: If %TRUE, force export even if the pool is in use.
+        @options: Additional options.
+
+        Exports the ZFS pool.
+    -->
+    <method name="Export">
+      <arg name="force" direction="in" type="b"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        Destroy:
+        @force: If %TRUE, force destroy even if the pool is in use.
+        @options: Additional options.
+
+        Destroys the ZFS pool.
+    -->
+    <method name="Destroy">
+      <arg name="force" direction="in" type="b"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        AddVdev:
+        @vdev_type: The vdev type (e.g. "mirror", "raidz", "cache", "log", "spare").
+        @blocks: An array of object paths to objects implementing the #org.freedesktop.UDisks2.Block interface.
+        @options: Additional options.
+
+        Adds a vdev to the pool.
+    -->
+    <method name="AddVdev">
+      <arg name="vdev_type" direction="in" type="s"/>
+      <arg name="blocks" direction="in" type="ao"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        RemoveVdev:
+        @device: The device name to remove from the pool.
+        @options: Additional options.
+
+        Removes a vdev from the pool.
+    -->
+    <method name="RemoveVdev">
+      <arg name="device" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        ScrubStart:
+        @options: Additional options.
+
+        Starts a scrub on the pool.
+    -->
+    <method name="ScrubStart">
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        ScrubPause:
+        @options: Additional options.
+
+        Pauses a running scrub on the pool.
+    -->
+    <method name="ScrubPause">
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        ScrubStop:
+        @options: Additional options.
+
+        Stops a running scrub on the pool.
+    -->
+    <method name="ScrubStop">
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        TrimStart:
+        @options: Additional options.
+
+        Starts a TRIM on the pool.
+    -->
+    <method name="TrimStart">
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        SetProperty:
+        @name: The property name.
+        @value: The property value.
+        @options: Additional options.
+
+        Sets a pool property.
+    -->
+    <method name="SetProperty">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="value" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        GetProperty:
+        @name: The property name.
+        @options: Additional options.
+        @value: The property value.
+        @source: The property source.
+
+        Gets a pool property.
+    -->
+    <method name="GetProperty">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="value" direction="out" type="s"/>
+      <arg name="source" direction="out" type="s"/>
+    </method>
+
+    <!--
+        CreateDataset:
+        @name: The dataset name (relative to the pool).
+        @options: Additional options.
+        @result: The full dataset name.
+
+        Creates a new ZFS dataset (filesystem).
+    -->
+    <method name="CreateDataset">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="result" direction="out" type="s"/>
+    </method>
+
+    <!--
+        CreateVolume:
+        @name: The volume name (relative to the pool).
+        @size: The volume size in bytes.
+        @options: Additional options.
+        @result: The full volume name.
+
+        Creates a new ZFS volume (zvol).
+    -->
+    <method name="CreateVolume">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="size" direction="in" type="t"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="result" direction="out" type="s"/>
+    </method>
+
+    <!--
+        ListDatasets:
+        @options: Additional options.
+        @datasets: An array of dictionaries with dataset properties.
+
+        Lists all datasets in the pool.
+    -->
+    <method name="ListDatasets">
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="datasets" direction="out" type="aa{sv}"/>
+    </method>
+
+    <!--
+        DestroyDataset:
+        @name: The dataset name to destroy.
+        @recursive: If %TRUE, destroy all children recursively.
+        @options: Additional options.
+
+        Destroys a ZFS dataset.
+    -->
+    <method name="DestroyDataset">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="recursive" direction="in" type="b"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        MountDataset:
+        @name: The dataset name to mount.
+        @options: Additional options.
+
+        Mounts a ZFS dataset.
+    -->
+    <method name="MountDataset">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        UnmountDataset:
+        @name: The dataset name to unmount.
+        @force: If %TRUE, force unmount.
+        @options: Additional options.
+
+        Unmounts a ZFS dataset.
+    -->
+    <method name="UnmountDataset">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="force" direction="in" type="b"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        CreateSnapshot:
+        @dataset: The dataset name to snapshot.
+        @snap_name: The snapshot name.
+        @recursive: If %TRUE, create snapshots recursively.
+        @options: Additional options.
+
+        Creates a ZFS snapshot.
+    -->
+    <method name="CreateSnapshot">
+      <arg name="dataset" direction="in" type="s"/>
+      <arg name="snap_name" direction="in" type="s"/>
+      <arg name="recursive" direction="in" type="b"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        RollbackSnapshot:
+        @name: The snapshot name to rollback to.
+        @options: Additional options.
+
+        Rolls back to a ZFS snapshot.
+    -->
+    <method name="RollbackSnapshot">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        CloneSnapshot:
+        @snapshot: The snapshot name to clone.
+        @clone_name: The name for the clone.
+        @options: Additional options.
+        @result: The full clone name.
+
+        Clones a ZFS snapshot.
+    -->
+    <method name="CloneSnapshot">
+      <arg name="snapshot" direction="in" type="s"/>
+      <arg name="clone_name" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="result" direction="out" type="s"/>
+    </method>
+
+    <!--
+        RenameDataset:
+        @name: The dataset name to rename.
+        @new_name: The new name for the dataset.
+        @options: Additional options.
+
+        Renames a ZFS dataset.
+    -->
+    <method name="RenameDataset">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="new_name" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        SetDatasetProperty:
+        @dataset: The dataset name.
+        @property: The property name.
+        @value: The property value.
+        @options: Additional options.
+
+        Sets a property on a ZFS dataset.
+    -->
+    <method name="SetDatasetProperty">
+      <arg name="dataset" direction="in" type="s"/>
+      <arg name="property" direction="in" type="s"/>
+      <arg name="value" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        GetDatasetProperty:
+        @dataset: The dataset name.
+        @property: The property name.
+        @options: Additional options.
+        @value: The property value.
+        @source: The property source.
+
+        Gets a property from a ZFS dataset.
+    -->
+    <method name="GetDatasetProperty">
+      <arg name="dataset" direction="in" type="s"/>
+      <arg name="property" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="value" direction="out" type="s"/>
+      <arg name="source" direction="out" type="s"/>
+    </method>
+
+    <!--
+        LoadKey:
+        @dataset: The encrypted dataset name.
+        @options: Additional options.
+
+        Loads the encryption key for a dataset.
+    -->
+    <method name="LoadKey">
+      <arg name="dataset" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        UnloadKey:
+        @dataset: The encrypted dataset name.
+        @options: Additional options.
+
+        Unloads the encryption key for a dataset.
+    -->
+    <method name="UnloadKey">
+      <arg name="dataset" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!--
+        ChangeKey:
+        @dataset: The encrypted dataset name.
+        @options: Additional options.
+
+        Changes the encryption key for a dataset.
+    -->
+    <method name="ChangeKey">
+      <arg name="dataset" direction="in" type="s"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+  </interface>
+
+  <!-- ********************************************************************** -->
+
+  <!--
+      org.freedesktop.UDisks2.Block.ZFS:
+      @short_description: ZFS block device interface
+
+      This interface is used for #org.freedesktop.UDisks2.Block devices that
+      are part of a ZFS pool.
+  -->
+  <interface name="org.freedesktop.UDisks2.Block.ZFS">
+    <property name="Pool" type="o" access="read"/>
+  </interface>
+
+  <!-- ********************************************************************** -->
+
+  <!--
+      org.freedesktop.UDisks2.Filesystem.ZFS:
+      @short_description: ZFS filesystem interface
+
+      This interface is used for #org.freedesktop.UDisks2.Block devices that
+      contain a ZFS filesystem.
+  -->
+  <interface name="org.freedesktop.UDisks2.Filesystem.ZFS">
+    <property name="Pool" type="o" access="read"/>
+    <property name="PoolName" type="s" access="read"/>
+    <property name="DatasetName" type="s" access="read"/>
+  </interface>
+
+</node>

--- a/modules/zfs/data/udisks2-zfs.pc.in
+++ b/modules/zfs/data/udisks2-zfs.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: UDisks ZFS module
+Description: UDisks ZFS module client library
+Version: @VERSION@
+Requires: gio-2.0,gobject-2.0,glib-2.0,udisks2
+Libs: -L${libdir}
+Cflags: -I${includedir}/udisks2

--- a/modules/zfs/udiskslinuxmanagerzfs.c
+++ b/modules/zfs/udiskslinuxmanagerzfs.c
@@ -1,0 +1,229 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+
+#include <src/udisksdaemon.h>
+#include <src/udisksdaemonutil.h>
+#include <src/udiskslogging.h>
+
+#include "udiskslinuxmanagerzfs.h"
+#include "udiskslinuxmodulezfs.h"
+
+/**
+ * SECTION:udiskslinuxmanagerzfs
+ * @title: UDisksLinuxManagerZFS
+ * @short_description: Linux implementation of #UDisksLinuxManagerZFS
+ *
+ * This type provides an implementation of the #UDisksLinuxManagerZFS
+ * interface on Linux.
+ */
+
+/**
+ * UDisksLinuxManagerZFS:
+ *
+ * The #UDisksLinuxManagerZFS structure contains only private data and
+ * should only be accessed using the provided API.
+ */
+struct _UDisksLinuxManagerZFS{
+  UDisksManagerZFSSkeleton parent_instance;
+
+  UDisksLinuxModuleZFS *module;
+};
+
+struct _UDisksLinuxManagerZFSClass {
+  UDisksManagerZFSSkeletonClass parent_class;
+};
+
+static void udisks_linux_manager_zfs_iface_init (UDisksManagerZFSIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (UDisksLinuxManagerZFS, udisks_linux_manager_zfs, UDISKS_TYPE_MANAGER_ZFS_SKELETON,
+                         G_IMPLEMENT_INTERFACE (UDISKS_TYPE_MANAGER_ZFS, udisks_linux_manager_zfs_iface_init));
+
+enum
+{
+  PROP_0,
+  PROP_MODULE,
+  N_PROPERTIES
+};
+
+static void
+udisks_linux_manager_zfs_get_property (GObject *object, guint property_id,
+                                       GValue *value, GParamSpec *pspec)
+{
+  UDisksLinuxManagerZFS *manager = UDISKS_LINUX_MANAGER_ZFS (object);
+
+  switch (property_id)
+    {
+    case PROP_MODULE:
+      g_value_set_object (value, udisks_linux_manager_zfs_get_module (manager));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+    }
+}
+
+static void
+udisks_linux_manager_zfs_set_property (GObject *object, guint property_id,
+                                       const GValue *value, GParamSpec *pspec)
+{
+  UDisksLinuxManagerZFS *manager = UDISKS_LINUX_MANAGER_ZFS (object);
+
+  switch (property_id)
+    {
+    case PROP_MODULE:
+      g_assert (manager->module == NULL);
+      manager->module = g_value_dup_object (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+    }
+}
+
+static void
+udisks_linux_manager_zfs_finalize (GObject *object)
+{
+  UDisksLinuxManagerZFS *manager = UDISKS_LINUX_MANAGER_ZFS (object);
+
+  g_object_unref (manager->module);
+
+  if (G_OBJECT_CLASS (udisks_linux_manager_zfs_parent_class))
+    G_OBJECT_CLASS (udisks_linux_manager_zfs_parent_class)->finalize (object);
+}
+
+static void
+udisks_linux_manager_zfs_class_init (UDisksLinuxManagerZFSClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+  gobject_class->get_property = udisks_linux_manager_zfs_get_property;
+  gobject_class->set_property = udisks_linux_manager_zfs_set_property;
+  gobject_class->finalize = udisks_linux_manager_zfs_finalize;
+
+  /**
+   * UDisksLinuxManagerZFS:module
+   *
+   * The #UDisksLinuxModuleZFS for the object.
+   */
+  g_object_class_install_property (gobject_class,
+                                   PROP_MODULE,
+                                   g_param_spec_object ("module",
+                                                        "Module",
+                                                        "The module for the object",
+                                                        UDISKS_TYPE_LINUX_MODULE_ZFS,
+                                                        G_PARAM_READABLE |
+                                                        G_PARAM_WRITABLE |
+                                                        G_PARAM_CONSTRUCT_ONLY |
+                                                        G_PARAM_STATIC_STRINGS));
+}
+
+static void
+udisks_linux_manager_zfs_init (UDisksLinuxManagerZFS *self)
+{
+  g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (self),
+                                       G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
+}
+
+/**
+ * udisks_linux_manager_zfs_new:
+ * @module: A #UDisksLinuxModuleZFS.
+ *
+ * Creates a new #UDisksLinuxManagerZFS instance.
+ *
+ * Returns: A new #UDisksLinuxManagerZFS. Free with g_object_unref().
+ */
+UDisksLinuxManagerZFS *
+udisks_linux_manager_zfs_new (UDisksLinuxModuleZFS *module)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_MODULE_ZFS (module), NULL);
+  return UDISKS_LINUX_MANAGER_ZFS (g_object_new (UDISKS_TYPE_LINUX_MANAGER_ZFS,
+                                                  "module", module,
+                                                  NULL));
+}
+
+/**
+ * udisks_linux_manager_zfs_get_module:
+ * @manager: A #UDisksLinuxManagerZFS.
+ *
+ * Gets the module used by @manager.
+ *
+ * Returns: A #UDisksLinuxModuleZFS. Do not free, the object is owned by @manager.
+ */
+UDisksLinuxModuleZFS *
+udisks_linux_manager_zfs_get_module (UDisksLinuxManagerZFS *manager)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_MANAGER_ZFS (manager), NULL);
+  return manager->module;
+}
+
+/* ---------------------------------------------------------------------------------------------------- */
+
+static gboolean
+handle_pool_create (UDisksManagerZFS      *manager,
+                    GDBusMethodInvocation *invocation,
+                    const gchar           *arg_name,
+                    const gchar *const    *arg_blocks,
+                    const gchar           *arg_vdev_type,
+                    GVariant              *arg_options)
+{
+  g_dbus_method_invocation_return_error (invocation,
+                                         G_DBUS_ERROR,
+                                         G_DBUS_ERROR_NOT_SUPPORTED,
+                                         "Method not yet implemented");
+  return TRUE;
+}
+
+static gboolean
+handle_pool_import (UDisksManagerZFS      *manager,
+                    GDBusMethodInvocation *invocation,
+                    const gchar           *arg_name_or_guid,
+                    GVariant              *arg_options)
+{
+  g_dbus_method_invocation_return_error (invocation,
+                                         G_DBUS_ERROR,
+                                         G_DBUS_ERROR_NOT_SUPPORTED,
+                                         "Method not yet implemented");
+  return TRUE;
+}
+
+static gboolean
+handle_pool_import_all (UDisksManagerZFS      *manager,
+                        GDBusMethodInvocation *invocation,
+                        GVariant              *arg_options)
+{
+  g_dbus_method_invocation_return_error (invocation,
+                                         G_DBUS_ERROR,
+                                         G_DBUS_ERROR_NOT_SUPPORTED,
+                                         "Method not yet implemented");
+  return TRUE;
+}
+
+static void
+udisks_linux_manager_zfs_iface_init (UDisksManagerZFSIface *iface)
+{
+  iface->handle_pool_create = handle_pool_create;
+  iface->handle_pool_import = handle_pool_import;
+  iface->handle_pool_import_all = handle_pool_import_all;
+}

--- a/modules/zfs/udiskslinuxmanagerzfs.h
+++ b/modules/zfs/udiskslinuxmanagerzfs.h
@@ -1,0 +1,41 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __UDISKS_LINUX_MANAGER_ZFS_H__
+#define __UDISKS_LINUX_MANAGER_ZFS_H__
+
+#include <src/udisksdaemontypes.h>
+#include "udiskszfstypes.h"
+
+G_BEGIN_DECLS
+
+#define UDISKS_TYPE_LINUX_MANAGER_ZFS            (udisks_linux_manager_zfs_get_type ())
+#define UDISKS_LINUX_MANAGER_ZFS(o)              (G_TYPE_CHECK_INSTANCE_CAST  ((o), UDISKS_TYPE_LINUX_MANAGER_ZFS, UDisksLinuxManagerZFS))
+#define UDISKS_IS_LINUX_MANAGER_ZFS(o)           (G_TYPE_CHECK_INSTANCE_TYPE  ((o), UDISKS_TYPE_LINUX_MANAGER_ZFS))
+#define UDISKS_LINUX_MANAGER_ZFS_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), UDISKS_TYPE_LINUX_MANAGER_ZFS, UDisksLinuxManagerZFSClass))
+#define UDISKS_IS_LINUX_MANAGER_ZFS_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), UDISKS_TYPE_LINUX_MANAGER_ZFS))
+#define UDISKS_LINUX_MANAGER_ZFS_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), UDISKS_TYPE_LINUX_MANAGER_ZFS, UDisksLinuxManagerZFSClass))
+
+GType                    udisks_linux_manager_zfs_get_type   (void) G_GNUC_CONST;
+UDisksLinuxManagerZFS   *udisks_linux_manager_zfs_new        (UDisksLinuxModuleZFS  *module);
+UDisksLinuxModuleZFS    *udisks_linux_manager_zfs_get_module (UDisksLinuxManagerZFS *manager);
+
+G_END_DECLS
+
+#endif /* __UDISKS_LINUX_MANAGER_ZFS_H__ */

--- a/modules/zfs/udiskslinuxmodulezfs.c
+++ b/modules/zfs/udiskslinuxmodulezfs.c
@@ -1,0 +1,180 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "config.h"
+
+#include <blockdev/blockdev.h>
+#include <blockdev/zfs.h>
+
+#include <src/udisksdaemon.h>
+#include <src/udiskslogging.h>
+#include <src/udiskslinuxdevice.h>
+#include <src/udisksmodulemanager.h>
+#include <src/udisksmodule.h>
+#include <src/udisksmoduleobject.h>
+
+#include "udiskslinuxmodulezfs.h"
+#include "udiskslinuxmanagerzfs.h"
+
+/**
+ * SECTION:udiskslinuxmodulezfs
+ * @title: UDisksLinuxModuleZFS
+ * @short_description: ZFS module.
+ *
+ * The ZFS module.
+ */
+
+/**
+ * UDisksLinuxModuleZFS:
+ *
+ * The #UDisksLinuxModuleZFS structure contains only private data
+ * and should only be accessed using the provided API.
+ */
+struct _UDisksLinuxModuleZFS {
+  UDisksModule parent_instance;
+
+};
+
+typedef struct _UDisksLinuxModuleZFSClass UDisksLinuxModuleZFSClass;
+
+struct _UDisksLinuxModuleZFSClass {
+  UDisksModuleClass parent_class;
+};
+
+static void initable_iface_init (GInitableIface *initable_iface);
+
+G_DEFINE_TYPE_WITH_CODE (UDisksLinuxModuleZFS, udisks_linux_module_zfs, UDISKS_TYPE_MODULE,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, initable_iface_init));
+
+
+static void
+udisks_linux_module_zfs_init (UDisksLinuxModuleZFS *module)
+{
+}
+
+static void
+udisks_linux_module_zfs_constructed (GObject *object)
+{
+  if (G_OBJECT_CLASS (udisks_linux_module_zfs_parent_class)->constructed)
+    G_OBJECT_CLASS (udisks_linux_module_zfs_parent_class)->constructed (object);
+}
+
+static void
+udisks_linux_module_zfs_finalize (GObject *object)
+{
+  if (G_OBJECT_CLASS (udisks_linux_module_zfs_parent_class)->finalize)
+    G_OBJECT_CLASS (udisks_linux_module_zfs_parent_class)->finalize (object);
+}
+
+gchar *
+udisks_module_id (void)
+{
+  return g_strdup (ZFS_MODULE_NAME);
+}
+
+/**
+ * udisks_module_zfs_new:
+ * @daemon: A #UDisksDaemon.
+ * @cancellable: (nullable): A #GCancellable or %NULL
+ * @error: Return location for error or %NULL.
+ *
+ * Creates new #UDisksLinuxModuleZFS object.
+ *
+ * Returns: (transfer full) (type UDisksLinuxModuleZFS): A
+ *   #UDisksLinuxModuleZFS object or %NULL if @error is set. Free
+ *   with g_object_unref().
+ */
+UDisksModule *
+udisks_module_zfs_new (UDisksDaemon  *daemon,
+                       GCancellable  *cancellable,
+                       GError       **error)
+{
+  GInitable *initable;
+
+  g_return_val_if_fail (UDISKS_IS_DAEMON (daemon), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+
+  initable = g_initable_new (UDISKS_TYPE_LINUX_MODULE_ZFS,
+                             cancellable,
+                             error,
+                             "daemon", daemon,
+                             "name", ZFS_MODULE_NAME,
+                             NULL);
+
+  if (initable == NULL)
+    return NULL;
+  else
+    return UDISKS_MODULE (initable);
+}
+
+/* ---------------------------------------------------------------------------------------------------- */
+
+static gboolean
+initable_init (GInitable     *initable,
+               GCancellable  *cancellable,
+               GError       **error)
+{
+  BDPluginSpec zfs_plugin = { BD_PLUGIN_ZFS, "libbd_zfs.so.3" };
+  BDPluginSpec *plugins[] = { &zfs_plugin, NULL };
+
+  if (! bd_is_plugin_available (BD_PLUGIN_ZFS))
+    {
+      if (! bd_reinit (plugins, FALSE, NULL, error))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+initable_iface_init (GInitableIface *initable_iface)
+{
+  initable_iface->init = initable_init;
+}
+
+/* ---------------------------------------------------------------------------------------------------- */
+
+static GDBusInterfaceSkeleton *
+udisks_linux_module_zfs_new_manager (UDisksModule *module)
+{
+  UDisksLinuxManagerZFS *manager;
+
+  g_return_val_if_fail (UDISKS_IS_LINUX_MODULE_ZFS (module), NULL);
+
+  manager = udisks_linux_manager_zfs_new (UDISKS_LINUX_MODULE_ZFS (module));
+
+  return G_DBUS_INTERFACE_SKELETON (manager);
+}
+
+/* ---------------------------------------------------------------------------------------------------- */
+
+static void
+udisks_linux_module_zfs_class_init (UDisksLinuxModuleZFSClass *klass)
+{
+  GObjectClass *gobject_class;
+  UDisksModuleClass *module_class;
+
+  gobject_class = G_OBJECT_CLASS (klass);
+  gobject_class->constructed = udisks_linux_module_zfs_constructed;
+  gobject_class->finalize = udisks_linux_module_zfs_finalize;
+
+  module_class = UDISKS_MODULE_CLASS (klass);
+  module_class->new_manager = udisks_linux_module_zfs_new_manager;
+}

--- a/modules/zfs/udiskslinuxmodulezfs.h
+++ b/modules/zfs/udiskslinuxmodulezfs.h
@@ -1,0 +1,47 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __UDISKS_LINUX_MODULE_ZFS_H__
+#define __UDISKS_LINUX_MODULE_ZFS_H__
+
+#include <src/udisksdaemontypes.h>
+#include <src/udisksmodule.h>
+#include "udiskszfstypes.h"
+
+G_BEGIN_DECLS
+
+#define UDISKS_TYPE_LINUX_MODULE_ZFS            (udisks_linux_module_zfs_get_type ())
+#define UDISKS_LINUX_MODULE_ZFS(o)              (G_TYPE_CHECK_INSTANCE_CAST ((o), UDISKS_TYPE_LINUX_MODULE_ZFS, UDisksLinuxModuleZFS))
+#define UDISKS_IS_LINUX_MODULE_ZFS(o)           (G_TYPE_CHECK_INSTANCE_TYPE ((o), UDISKS_TYPE_LINUX_MODULE_ZFS))
+
+GType                   udisks_linux_module_zfs_get_type   (void) G_GNUC_CONST;
+
+/* Corresponds with the UDisksModuleIDFunc type */
+G_MODULE_EXPORT
+gchar                  *udisks_module_id                    (void);
+
+G_MODULE_EXPORT
+UDisksModule           *udisks_module_zfs_new              (UDisksDaemon  *daemon,
+                                                            GCancellable  *cancellable,
+                                                            GError       **error);
+
+G_END_DECLS
+
+#endif /* __UDISKS_LINUX_MODULE_ZFS_H__ */

--- a/modules/zfs/udiskszfstypes.h
+++ b/modules/zfs/udiskszfstypes.h
@@ -1,0 +1,37 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __UDISKS_ZFS_TYPES_H__
+#define __UDISKS_ZFS_TYPES_H__
+
+#define ZFS_MODULE_NAME "zfs"
+#define ZFS_POLICY_ACTION_ID "org.freedesktop.udisks2.zfs.manage-zfs"
+#define ZFS_POLICY_ACTION_ID_QUERY "org.freedesktop.udisks2.zfs.query"
+#define ZFS_POLICY_ACTION_ID_DESTROY "org.freedesktop.udisks2.zfs.manage-zfs-destroy"
+
+struct _UDisksLinuxModuleZFS;
+typedef struct _UDisksLinuxModuleZFS UDisksLinuxModuleZFS;
+
+typedef struct _UDisksLinuxManagerZFS        UDisksLinuxManagerZFS;
+typedef struct _UDisksLinuxManagerZFSClass   UDisksLinuxManagerZFSClass;
+
+typedef struct _UDisksLinuxPoolObjectZFS        UDisksLinuxPoolObjectZFS;
+typedef struct _UDisksLinuxPoolObjectZFSClass   UDisksLinuxPoolObjectZFSClass;
+
+#endif /* __UDISKS_ZFS_TYPES_H__ */

--- a/udisks/Makefile.am
+++ b/udisks/Makefile.am
@@ -44,6 +44,10 @@ if HAVE_LSM
 dbus_interface_files += $(top_srcdir)/modules/lsm/data/org.freedesktop.UDisks2.lsm.xml
 endif
 
+if HAVE_ZFS
+dbus_interface_files += $(top_srcdir)/modules/zfs/data/org.freedesktop.UDisks2.zfs.xml
+endif
+
 $(dbus_built_sources) : Makefile.am $(dbus_interface_files)
 	mkdir -p $(top_builddir)/doc/xml &&						\
 	gdbus-codegen									\


### PR DESCRIPTION
## Summary

- Create `modules/zfs/` with loadable UDisks ZFS module
- Full D-Bus interface XML committed early for API stability (4 interfaces, 22+ methods, 16+ properties)
- 3-tier polkit policy: query (no auth), manage (auth_admin_keep), destroy (auth_admin)
- Module loads and exports Manager.ZFS on `/org/freedesktop/UDisks2/Manager`
- All methods return NotSupported until implemented in U2-U10
- Build system: `--enable-zfs` configure flag, gdbus-codegen integration

## Test plan

- [ ] Build succeeds with `--enable-zfs` (requires libblockdev ZFS plugin installed)
- [ ] Build succeeds without `--enable-zfs` (no regression)
- [ ] Module loads: `Manager.ZFS` interface visible via `gdbus introspect`
- [ ] All stub methods return `org.freedesktop.DBus.Error.NotSupported`
- [ ] Polkit policy installed with 3 actions

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)