### PR TITLE
U2: Add ZFS pool discovery with handle_uevent and periodic poll

### DIFF
--- a/modules/zfs/Makefile.am
+++ b/modules/zfs/Makefile.am
@@ -43,6 +43,8 @@ libudisks2_zfs_la_SOURCES =                                                    \
 	udiskslinuxmodulezfs.c                                                 \
 	udiskslinuxmanagerzfs.h                                                \
 	udiskslinuxmanagerzfs.c                                                \
+	udiskslinuxpoolobjectzfs.h                                             \
+	udiskslinuxpoolobjectzfs.c                                             \
 	udiskszfstypes.h                                                       \
 	$(NULL)
 

--- a/modules/zfs/udiskslinuxmodulezfs.c
+++ b/modules/zfs/udiskslinuxmodulezfs.c
@@ -30,8 +30,10 @@
 #include <src/udisksmodule.h>
 #include <src/udisksmoduleobject.h>
 
+#include "udiskszfstypes.h"
 #include "udiskslinuxmodulezfs.h"
 #include "udiskslinuxmanagerzfs.h"
+#include "udiskslinuxpoolobjectzfs.h"
 
 /**
  * SECTION:udiskslinuxmodulezfs
@@ -50,6 +52,14 @@
 struct _UDisksLinuxModuleZFS {
   UDisksModule parent_instance;
 
+  /* maps from pool name to UDisksLinuxPoolObjectZFS instances */
+  GHashTable *name_to_pool;
+
+  gint delayed_update_id;
+  gint periodic_poll_id;       /* 30-second poll source */
+  gboolean coldplug_done;
+
+  guint32 update_epoch;
 };
 
 typedef struct _UDisksLinuxModuleZFSClass UDisksLinuxModuleZFSClass;
@@ -67,11 +77,34 @@ G_DEFINE_TYPE_WITH_CODE (UDisksLinuxModuleZFS, udisks_linux_module_zfs, UDISKS_T
 static void
 udisks_linux_module_zfs_init (UDisksLinuxModuleZFS *module)
 {
+  g_return_if_fail (UDISKS_IS_LINUX_MODULE_ZFS (module));
+}
+
+static void zfs_update (UDisksLinuxModuleZFS *module);
+
+static gboolean
+periodic_poll (gpointer user_data)
+{
+  UDisksLinuxModuleZFS *module = UDISKS_LINUX_MODULE_ZFS (user_data);
+
+  zfs_update (module);
+
+  return G_SOURCE_CONTINUE;
 }
 
 static void
 udisks_linux_module_zfs_constructed (GObject *object)
 {
+  UDisksLinuxModuleZFS *module = UDISKS_LINUX_MODULE_ZFS (object);
+
+  module->name_to_pool = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, (GDestroyNotify) g_object_unref);
+  module->coldplug_done = FALSE;
+  module->update_epoch = 0;
+  module->delayed_update_id = 0;
+
+  /* Start a 30-second periodic poll to catch CLI-driven changes */
+  module->periodic_poll_id = g_timeout_add_seconds (30, periodic_poll, module);
+
   if (G_OBJECT_CLASS (udisks_linux_module_zfs_parent_class)->constructed)
     G_OBJECT_CLASS (udisks_linux_module_zfs_parent_class)->constructed (object);
 }
@@ -79,6 +112,16 @@ udisks_linux_module_zfs_constructed (GObject *object)
 static void
 udisks_linux_module_zfs_finalize (GObject *object)
 {
+  UDisksLinuxModuleZFS *module = UDISKS_LINUX_MODULE_ZFS (object);
+
+  if (module->delayed_update_id > 0)
+    g_source_remove (module->delayed_update_id);
+
+  if (module->periodic_poll_id > 0)
+    g_source_remove (module->periodic_poll_id);
+
+  g_hash_table_unref (module->name_to_pool);
+
   if (G_OBJECT_CLASS (udisks_linux_module_zfs_parent_class)->finalize)
     G_OBJECT_CLASS (udisks_linux_module_zfs_parent_class)->finalize (object);
 }
@@ -151,6 +194,26 @@ initable_iface_init (GInitableIface *initable_iface)
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+GHashTable *
+udisks_linux_module_zfs_get_name_to_pool (UDisksLinuxModuleZFS *module)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_MODULE_ZFS (module), NULL);
+
+  return module->name_to_pool;
+}
+
+/*  transfer-none  */
+UDisksLinuxPoolObjectZFS *
+udisks_linux_module_zfs_find_pool_object (UDisksLinuxModuleZFS *module,
+                                          const gchar          *name)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_MODULE_ZFS (module), NULL);
+
+  return g_hash_table_lookup (module->name_to_pool, name);
+}
+
+/* ---------------------------------------------------------------------------------------------------- */
+
 static GDBusInterfaceSkeleton *
 udisks_linux_module_zfs_new_manager (UDisksModule *module)
 {
@@ -161,6 +224,200 @@ udisks_linux_module_zfs_new_manager (UDisksModule *module)
   manager = udisks_linux_manager_zfs_new (UDISKS_LINUX_MODULE_ZFS (module));
 
   return G_DBUS_INTERFACE_SKELETON (manager);
+}
+
+/* ---------------------------------------------------------------------------------------------------- */
+
+static void
+pool_list_free (BDZFSPoolInfo **pool_list)
+{
+  if (pool_list == NULL)
+    return;
+  for (BDZFSPoolInfo **p = pool_list; *p != NULL; p++)
+    bd_zfs_pool_info_free (*p);
+  g_free (pool_list);
+}
+
+static void
+zfs_pools_task_func (GTask        *task,
+                     gpointer      source_obj,
+                     gpointer      task_data,
+                     GCancellable *cancellable)
+{
+  GError *error = NULL;
+  BDZFSPoolInfo **pools;
+
+  pools = bd_zfs_pool_list (&error);
+
+  if (pools == NULL && error != NULL)
+    {
+      g_task_return_error (task, error);
+      return;
+    }
+
+  /* bd_zfs_pool_list may return NULL with no error when there are no pools.
+   * In that case, return an empty NULL-terminated array. */
+  if (pools == NULL)
+    {
+      pools = g_new0 (BDZFSPoolInfo *, 1);
+    }
+
+  g_task_return_pointer (task, pools, (GDestroyNotify) pool_list_free);
+}
+
+static void
+zfs_update_pools (GObject      *source_obj,
+                  GAsyncResult *result,
+                  gpointer      user_data)
+{
+  UDisksLinuxModuleZFS *module = UDISKS_LINUX_MODULE_ZFS (source_obj);
+  UDisksDaemon *daemon;
+  GDBusObjectManagerServer *manager;
+
+  GTask *task = G_TASK (result);
+  GError *error = NULL;
+  BDZFSPoolInfo **pools = g_task_propagate_pointer (task, &error);
+  BDZFSPoolInfo **pools_p;
+
+  GHashTableIter pool_name_iter;
+  gpointer key, value;
+  const gchar *pool_name;
+
+  /* Reject stale async results */
+  if (GPOINTER_TO_UINT (user_data) != module->update_epoch)
+    {
+      pool_list_free (pools);
+      return;
+    }
+
+  if (! pools)
+    {
+      if (error)
+        {
+          udisks_warning ("ZFS plugin: %s", error->message);
+          g_clear_error (&error);
+        }
+      else
+        {
+          /* this should never happen */
+          udisks_warning ("ZFS plugin: failure but no error when getting pools!");
+        }
+      return;
+    }
+
+  daemon = udisks_module_get_daemon (UDISKS_MODULE (module));
+  manager = udisks_daemon_get_object_manager (daemon);
+
+  /* Remove obsolete pools */
+  g_hash_table_iter_init (&pool_name_iter, module->name_to_pool);
+  while (g_hash_table_iter_next (&pool_name_iter, &key, &value))
+    {
+      UDisksLinuxPoolObjectZFS *pool;
+      gboolean found = FALSE;
+
+      pool_name = key;
+      pool = value;
+
+      for (pools_p = pools; !found && *pools_p; pools_p++)
+        found = g_strcmp0 ((*pools_p)->name, pool_name) == 0;
+
+      if (! found)
+        {
+          udisks_linux_pool_object_zfs_destroy (pool);
+          g_dbus_object_manager_server_unexport (manager, g_dbus_object_get_object_path (G_DBUS_OBJECT (pool)));
+          g_hash_table_iter_remove (&pool_name_iter);
+        }
+    }
+
+  /* Add new pools and update existing pools */
+  for (pools_p = pools; *pools_p; pools_p++)
+    {
+      UDisksLinuxPoolObjectZFS *pool;
+
+      pool_name = (*pools_p)->name;
+      pool = g_hash_table_lookup (module->name_to_pool, pool_name);
+      if (pool == NULL)
+        {
+          pool = udisks_linux_pool_object_zfs_new (module, pool_name);
+          g_hash_table_insert (module->name_to_pool, g_strdup (pool_name), pool);
+          g_dbus_object_manager_server_export_uniquely (manager, G_DBUS_OBJECT_SKELETON (pool));
+        }
+
+      udisks_linux_pool_object_zfs_update (pool, *pools_p);
+    }
+
+  /* Free pool info array (but contents have been consumed) */
+  pool_list_free (pools);
+}
+
+static void
+zfs_update (UDisksLinuxModuleZFS *module)
+{
+  GTask *task;
+
+  module->update_epoch++;
+
+  /* the callback (zfs_update_pools) is called in the default main loop (context) */
+  task = g_task_new (module,
+                     NULL /* cancellable */,
+                     zfs_update_pools,
+                     GUINT_TO_POINTER (module->update_epoch));
+
+  /* holds a reference to 'task' until it is finished */
+  g_task_run_in_thread (task, (GTaskThreadFunc) zfs_pools_task_func);
+  g_object_unref (task);
+}
+
+static gboolean
+delayed_zfs_update (gpointer user_data)
+{
+  UDisksLinuxModuleZFS *module = UDISKS_LINUX_MODULE_ZFS (user_data);
+
+  zfs_update (module);
+  module->delayed_update_id = 0;
+
+  return FALSE;
+}
+
+static void
+trigger_delayed_zfs_update (UDisksLinuxModuleZFS *module)
+{
+  if (module->delayed_update_id > 0)
+    return;
+
+  if (! module->coldplug_done)
+    {
+      /* Update immediately when doing coldplug, i.e. when zfs module has just
+       * been activated. This is not 100% effective as this affects only the
+       * first request but from the plugin nature we don't know whether
+       * coldplugging has been finished or not. Might be subject to change in
+       * the future. */
+      module->coldplug_done = TRUE;
+      zfs_update (module);
+    }
+  else
+    {
+      module->delayed_update_id = g_timeout_add (100, delayed_zfs_update, module);
+    }
+}
+
+static gboolean
+has_zfs_member_label (UDisksLinuxDevice *device)
+{
+  const gchar *id_fs_type;
+
+  id_fs_type = g_udev_device_get_property (device->udev_device, "ID_FS_TYPE");
+  return g_strcmp0 (id_fs_type, "zfs_member") == 0;
+}
+
+static void
+udisks_linux_module_zfs_handle_uevent (UDisksModule      *module,
+                                       UDisksLinuxDevice *device)
+{
+  g_return_if_fail (UDISKS_IS_LINUX_MODULE_ZFS (module));
+
+  if (has_zfs_member_label (device))
+    trigger_delayed_zfs_update (UDISKS_LINUX_MODULE_ZFS (module));
 }
 
 /* ---------------------------------------------------------------------------------------------------- */
@@ -177,4 +434,5 @@ udisks_linux_module_zfs_class_init (UDisksLinuxModuleZFSClass *klass)
 
   module_class = UDISKS_MODULE_CLASS (klass);
   module_class->new_manager = udisks_linux_module_zfs_new_manager;
+  module_class->handle_uevent = udisks_linux_module_zfs_handle_uevent;
 }

--- a/modules/zfs/udiskslinuxmodulezfs.h
+++ b/modules/zfs/udiskslinuxmodulezfs.h
@@ -42,6 +42,11 @@ UDisksModule           *udisks_module_zfs_new              (UDisksDaemon  *daemo
                                                             GCancellable  *cancellable,
                                                             GError       **error);
 
+UDisksLinuxPoolObjectZFS *udisks_linux_module_zfs_find_pool_object  (UDisksLinuxModuleZFS *module,
+                                                                     const gchar          *name);
+
+GHashTable               *udisks_linux_module_zfs_get_name_to_pool  (UDisksLinuxModuleZFS *module);
+
 G_END_DECLS
 
 #endif /* __UDISKS_LINUX_MODULE_ZFS_H__ */

--- a/modules/zfs/udiskslinuxpoolobjectzfs.c
+++ b/modules/zfs/udiskslinuxpoolobjectzfs.c
@@ -1,0 +1,337 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+#include <glib/gi18n-lib.h>
+
+#include <string.h>
+
+#include <src/udiskslogging.h>
+#include <src/udisksdaemon.h>
+#include <src/udisksdaemonutil.h>
+
+#include "udiskslinuxpoolobjectzfs.h"
+#include "udiskslinuxmodulezfs.h"
+
+/**
+ * SECTION:udiskslinuxpoolobjectzfs
+ * @title: UDisksLinuxPoolObjectZFS
+ * @short_description: Object representing a ZFS pool
+ */
+
+typedef struct _UDisksLinuxPoolObjectZFSClass UDisksLinuxPoolObjectZFSClass;
+
+/**
+ * UDisksLinuxPoolObjectZFS:
+ *
+ * The #UDisksLinuxPoolObjectZFS structure contains only private data and
+ * should only be accessed using the provided API.
+ */
+struct _UDisksLinuxPoolObjectZFS
+{
+  UDisksObjectSkeleton parent_instance;
+
+  UDisksLinuxModuleZFS *module;
+  gchar *name;
+
+  /* interface */
+  UDisksZFSPool *iface_zfs_pool;
+};
+
+struct _UDisksLinuxPoolObjectZFSClass
+{
+  UDisksObjectSkeletonClass parent_class;
+};
+
+enum
+{
+  PROP_0,
+  PROP_MODULE,
+  PROP_NAME,
+};
+
+G_DEFINE_TYPE (UDisksLinuxPoolObjectZFS, udisks_linux_pool_object_zfs, UDISKS_TYPE_OBJECT_SKELETON);
+
+static void
+udisks_linux_pool_object_zfs_finalize (GObject *_object)
+{
+  UDisksLinuxPoolObjectZFS *object = UDISKS_LINUX_POOL_OBJECT_ZFS (_object);
+
+  g_object_unref (object->module);
+
+  if (object->iface_zfs_pool != NULL)
+    g_object_unref (object->iface_zfs_pool);
+
+  g_free (object->name);
+
+  if (G_OBJECT_CLASS (udisks_linux_pool_object_zfs_parent_class)->finalize != NULL)
+    G_OBJECT_CLASS (udisks_linux_pool_object_zfs_parent_class)->finalize (_object);
+}
+
+static void
+udisks_linux_pool_object_zfs_get_property (GObject    *__object,
+                                           guint       prop_id,
+                                           GValue     *value,
+                                           GParamSpec *pspec)
+{
+  UDisksLinuxPoolObjectZFS *object = UDISKS_LINUX_POOL_OBJECT_ZFS (__object);
+
+  switch (prop_id)
+    {
+    case PROP_MODULE:
+      g_value_set_object (value, udisks_linux_pool_object_zfs_get_module (object));
+      break;
+
+    case PROP_NAME:
+      g_value_set_string (value, udisks_linux_pool_object_zfs_get_name (object));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+udisks_linux_pool_object_zfs_set_property (GObject      *__object,
+                                           guint         prop_id,
+                                           const GValue *value,
+                                           GParamSpec   *pspec)
+{
+  UDisksLinuxPoolObjectZFS *object = UDISKS_LINUX_POOL_OBJECT_ZFS (__object);
+
+  switch (prop_id)
+    {
+    case PROP_MODULE:
+      g_assert (object->module == NULL);
+      object->module = g_value_dup_object (value);
+      break;
+
+    case PROP_NAME:
+      g_assert (object->name == NULL);
+      object->name = g_value_dup_string (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+udisks_linux_pool_object_zfs_init (UDisksLinuxPoolObjectZFS *object)
+{
+}
+
+static const gchar *
+pool_state_to_string (BDZFSPoolState state)
+{
+  switch (state)
+    {
+    case BD_ZFS_POOL_STATE_ONLINE:
+      return "ONLINE";
+    case BD_ZFS_POOL_STATE_DEGRADED:
+      return "DEGRADED";
+    case BD_ZFS_POOL_STATE_FAULTED:
+      return "FAULTED";
+    case BD_ZFS_POOL_STATE_OFFLINE:
+      return "OFFLINE";
+    case BD_ZFS_POOL_STATE_REMOVED:
+      return "REMOVED";
+    case BD_ZFS_POOL_STATE_UNAVAIL:
+      return "UNAVAIL";
+    case BD_ZFS_POOL_STATE_UNKNOWN:
+    default:
+      return "UNKNOWN";
+    }
+}
+
+static void
+udisks_linux_pool_object_zfs_constructed (GObject *_object)
+{
+  UDisksLinuxPoolObjectZFS *object = UDISKS_LINUX_POOL_OBJECT_ZFS (_object);
+  GString *s;
+
+  if (G_OBJECT_CLASS (udisks_linux_pool_object_zfs_parent_class)->constructed != NULL)
+    G_OBJECT_CLASS (udisks_linux_pool_object_zfs_parent_class)->constructed (_object);
+
+  /* compute the object path */
+  s = g_string_new ("/org/freedesktop/UDisks2/zfs/");
+  udisks_safe_append_to_object_path (s, object->name);
+  g_dbus_object_skeleton_set_object_path (G_DBUS_OBJECT_SKELETON (object), s->str);
+  g_string_free (s, TRUE);
+
+  /* create the D-Bus interface */
+  object->iface_zfs_pool = udisks_zfspool_skeleton_new ();
+  g_dbus_object_skeleton_add_interface (G_DBUS_OBJECT_SKELETON (object),
+                                        G_DBUS_INTERFACE_SKELETON (object->iface_zfs_pool));
+}
+
+static void
+udisks_linux_pool_object_zfs_class_init (UDisksLinuxPoolObjectZFSClass *klass)
+{
+  GObjectClass *gobject_class;
+
+  gobject_class = G_OBJECT_CLASS (klass);
+  gobject_class->finalize     = udisks_linux_pool_object_zfs_finalize;
+  gobject_class->constructed  = udisks_linux_pool_object_zfs_constructed;
+  gobject_class->set_property = udisks_linux_pool_object_zfs_set_property;
+  gobject_class->get_property = udisks_linux_pool_object_zfs_get_property;
+
+  /**
+   * UDisksLinuxPoolObjectZFS:module:
+   *
+   * The #UDisksLinuxModuleZFS the object is for.
+   */
+  g_object_class_install_property (gobject_class,
+                                   PROP_MODULE,
+                                   g_param_spec_object ("module",
+                                                        "Module",
+                                                        "The module the object is for",
+                                                        UDISKS_TYPE_LINUX_MODULE_ZFS,
+                                                        G_PARAM_READABLE |
+                                                        G_PARAM_WRITABLE |
+                                                        G_PARAM_CONSTRUCT_ONLY |
+                                                        G_PARAM_STATIC_STRINGS));
+
+  /**
+   * UDisksLinuxPoolObjectZFS:name:
+   *
+   * The name of the ZFS pool.
+   */
+  g_object_class_install_property (gobject_class,
+                                   PROP_NAME,
+                                   g_param_spec_string ("name",
+                                                        "Name",
+                                                        "The name of the ZFS pool",
+                                                        NULL,
+                                                        G_PARAM_WRITABLE |
+                                                        G_PARAM_CONSTRUCT_ONLY |
+                                                        G_PARAM_STATIC_STRINGS));
+}
+
+/**
+ * udisks_linux_pool_object_zfs_new:
+ * @module: A #UDisksLinuxModuleZFS.
+ * @name: The name of the ZFS pool.
+ *
+ * Create a new ZFS pool object.
+ *
+ * Returns: A #UDisksLinuxPoolObjectZFS object. Free with g_object_unref().
+ */
+UDisksLinuxPoolObjectZFS *
+udisks_linux_pool_object_zfs_new (UDisksLinuxModuleZFS *module,
+                                  const gchar          *name)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_MODULE_ZFS (module), NULL);
+  g_return_val_if_fail (name != NULL, NULL);
+  return UDISKS_LINUX_POOL_OBJECT_ZFS (g_object_new (UDISKS_TYPE_LINUX_POOL_OBJECT_ZFS,
+                                                      "module", module,
+                                                      "name", name,
+                                                      NULL));
+}
+
+/**
+ * udisks_linux_pool_object_zfs_get_module:
+ * @object: A #UDisksLinuxPoolObjectZFS.
+ *
+ * Gets the module used by @object.
+ *
+ * Returns: A #UDisksLinuxModuleZFS. Do not free, the object is owned by @object.
+ */
+UDisksLinuxModuleZFS *
+udisks_linux_pool_object_zfs_get_module (UDisksLinuxPoolObjectZFS *object)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_POOL_OBJECT_ZFS (object), NULL);
+  return object->module;
+}
+
+/**
+ * udisks_linux_pool_object_zfs_get_name:
+ * @object: A #UDisksLinuxPoolObjectZFS.
+ *
+ * Gets the name for @object.
+ *
+ * Returns: (transfer none): The name for object. Do not free, the string belongs to @object.
+ */
+const gchar *
+udisks_linux_pool_object_zfs_get_name (UDisksLinuxPoolObjectZFS *object)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_POOL_OBJECT_ZFS (object), NULL);
+  return object->name;
+}
+
+/**
+ * udisks_linux_pool_object_zfs_update:
+ * @object: A #UDisksLinuxPoolObjectZFS.
+ * @info: A #BDZFSPoolInfo with the pool info.
+ *
+ * Updates the pool object with the latest information from ZFS.
+ */
+void
+udisks_linux_pool_object_zfs_update (UDisksLinuxPoolObjectZFS *object,
+                                     BDZFSPoolInfo            *info)
+{
+  UDisksZFSPool *iface;
+
+  g_return_if_fail (UDISKS_IS_LINUX_POOL_OBJECT_ZFS (object));
+  g_return_if_fail (info != NULL);
+
+  iface = object->iface_zfs_pool;
+
+  udisks_zfspool_set_name (iface, info->name);
+  udisks_zfspool_set_guid (iface, info->guid ? info->guid : "");
+  udisks_zfspool_set_state (iface, pool_state_to_string (info->state));
+  udisks_zfspool_set_size (iface, info->size);
+  udisks_zfspool_set_allocated (iface, info->allocated);
+  udisks_zfspool_set_free (iface, info->free);
+  udisks_zfspool_set_fragmentation (iface, info->fragmentation);
+  udisks_zfspool_set_dedup_ratio (iface, info->dedup_ratio);
+  udisks_zfspool_set_read_only (iface, info->readonly);
+  udisks_zfspool_set_altroot (iface, info->altroot ? info->altroot : "");
+  udisks_zfspool_set_health (iface, pool_state_to_string (info->state));
+
+  /* Scrub info and feature flags require separate queries;
+   * set safe defaults here. They will be populated by a full
+   * status update later. */
+  {
+    const gchar *const empty_strv[] = { NULL };
+    udisks_zfspool_set_feature_flags (iface, empty_strv);
+  }
+
+  g_dbus_interface_skeleton_flush (G_DBUS_INTERFACE_SKELETON (iface));
+}
+
+/**
+ * udisks_linux_pool_object_zfs_destroy:
+ * @object: A #UDisksLinuxPoolObjectZFS.
+ *
+ * Destroys the pool object by removing its D-Bus interface.
+ */
+void
+udisks_linux_pool_object_zfs_destroy (UDisksLinuxPoolObjectZFS *object)
+{
+  g_return_if_fail (UDISKS_IS_LINUX_POOL_OBJECT_ZFS (object));
+
+  if (object->iface_zfs_pool != NULL)
+    {
+      g_dbus_object_skeleton_remove_interface (G_DBUS_OBJECT_SKELETON (object),
+                                               G_DBUS_INTERFACE_SKELETON (object->iface_zfs_pool));
+    }
+}

--- a/modules/zfs/udiskslinuxpoolobjectzfs.h
+++ b/modules/zfs/udiskslinuxpoolobjectzfs.h
@@ -1,0 +1,46 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __UDISKS_LINUX_POOL_OBJECT_ZFS_H__
+#define __UDISKS_LINUX_POOL_OBJECT_ZFS_H__
+
+#include <src/udisksdaemontypes.h>
+#include "udiskszfstypes.h"
+#include "udiskslinuxmodulezfs.h"
+
+#include <blockdev/zfs.h>
+
+G_BEGIN_DECLS
+
+#define UDISKS_TYPE_LINUX_POOL_OBJECT_ZFS  (udisks_linux_pool_object_zfs_get_type ())
+#define UDISKS_LINUX_POOL_OBJECT_ZFS(o)    (G_TYPE_CHECK_INSTANCE_CAST ((o), UDISKS_TYPE_LINUX_POOL_OBJECT_ZFS, UDisksLinuxPoolObjectZFS))
+#define UDISKS_IS_LINUX_POOL_OBJECT_ZFS(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), UDISKS_TYPE_LINUX_POOL_OBJECT_ZFS))
+
+GType                        udisks_linux_pool_object_zfs_get_type   (void) G_GNUC_CONST;
+UDisksLinuxPoolObjectZFS    *udisks_linux_pool_object_zfs_new        (UDisksLinuxModuleZFS *module,
+                                                                      const gchar          *name);
+const gchar                 *udisks_linux_pool_object_zfs_get_name   (UDisksLinuxPoolObjectZFS *object);
+UDisksLinuxModuleZFS        *udisks_linux_pool_object_zfs_get_module (UDisksLinuxPoolObjectZFS *object);
+void                         udisks_linux_pool_object_zfs_update     (UDisksLinuxPoolObjectZFS *object,
+                                                                      BDZFSPoolInfo            *info);
+void                         udisks_linux_pool_object_zfs_destroy    (UDisksLinuxPoolObjectZFS *object);
+
+G_END_DECLS
+
+#endif /* __UDISKS_LINUX_POOL_OBJECT_ZFS_H__ */


### PR DESCRIPTION
## Summary

- Implement pool discovery following LVM2 pattern (handle_uevent + delayed update + epoch)
- 30-second periodic poll catches CLI-driven pool changes
- Pool objects exported at /org/freedesktop/UDisks2/zfs/<name> with ZFSPool properties
- Epoch-based stale update rejection prevents race conditions

## Test plan

- [ ] Create ZFS pool externally → pool object appears on D-Bus
- [ ] Destroy pool externally → pool object disappears
- [ ] Pool properties match zpool list output
- [ ] Multiple rapid uevents batched correctly (100ms delay)
- [ ] Daemon restart → pools rediscovered via coldplug

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)