### PR TITLE
U6: Add Block.ZFS and Filesystem.ZFS interfaces

### DIFF
--- a/modules/zfs/Makefile.am
+++ b/modules/zfs/Makefile.am
@@ -45,6 +45,10 @@ libudisks2_zfs_la_SOURCES =                                                    \
 	udiskslinuxmanagerzfs.c                                                \
 	udiskslinuxpoolobjectzfs.h                                             \
 	udiskslinuxpoolobjectzfs.c                                             \
+	udiskslinuxblockzfs.h                                                  \
+	udiskslinuxblockzfs.c                                                  \
+	udiskslinuxfilesystemzfs.h                                             \
+	udiskslinuxfilesystemzfs.c                                             \
 	udiskszfstypes.h                                                       \
 	$(NULL)
 

--- a/modules/zfs/udiskslinuxblockzfs.c
+++ b/modules/zfs/udiskslinuxblockzfs.c
@@ -1,0 +1,301 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+#include <string.h>
+
+#include <src/udisksdaemon.h>
+#include <src/udisksdaemonutil.h>
+#include <src/udiskslinuxblockobject.h>
+#include <src/udiskslinuxdevice.h>
+#include <src/udiskslogging.h>
+#include <src/udisksmodule.h>
+#include <src/udisksmoduleobject.h>
+
+#include "udiskszfstypes.h"
+#include "udiskslinuxmodulezfs.h"
+#include "udiskslinuxblockzfs.h"
+#include "udiskslinuxpoolobjectzfs.h"
+
+/**
+ * SECTION:udiskslinuxblockzfs
+ * @title: UDisksLinuxBlockZFS
+ * @short_description: Linux implementation of #UDisksBlockZFS
+ *
+ * This type provides an implementation of #UDisksBlockZFS interface
+ * on Linux.
+ */
+
+/**
+ * UDisksLinuxBlockZFS:
+ *
+ * The #UDisksLinuxBlockZFS structure contains only private data and
+ * should be only accessed using provided API.
+ */
+struct _UDisksLinuxBlockZFS {
+  UDisksBlockZFSSkeleton parent_instance;
+
+  UDisksLinuxModuleZFS *module;
+  UDisksLinuxBlockObject *block_object;
+};
+
+struct _UDisksLinuxBlockZFSClass {
+  UDisksBlockZFSSkeletonClass parent_class;
+};
+
+enum
+{
+  PROP_0,
+  PROP_MODULE,
+  PROP_BLOCK_OBJECT,
+  N_PROPERTIES
+};
+
+static void udisks_linux_block_zfs_module_object_iface_init (UDisksModuleObjectIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (UDisksLinuxBlockZFS, udisks_linux_block_zfs, UDISKS_TYPE_BLOCK_ZFS_SKELETON,
+                         G_IMPLEMENT_INTERFACE (UDISKS_TYPE_BLOCK_ZFS, NULL)
+                         G_IMPLEMENT_INTERFACE (UDISKS_TYPE_MODULE_OBJECT, udisks_linux_block_zfs_module_object_iface_init));
+
+static void
+udisks_linux_block_zfs_get_property (GObject    *object,
+                                     guint       property_id,
+                                     GValue     *value,
+                                     GParamSpec *pspec)
+{
+  UDisksLinuxBlockZFS *block_zfs = UDISKS_LINUX_BLOCK_ZFS (object);
+
+  switch (property_id)
+    {
+    case PROP_MODULE:
+      g_value_set_object (value, UDISKS_MODULE (udisks_linux_block_zfs_get_module (block_zfs)));
+      break;
+
+    case PROP_BLOCK_OBJECT:
+      g_value_set_object (value, block_zfs->block_object);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+    }
+}
+
+static void
+udisks_linux_block_zfs_set_property (GObject      *object,
+                                     guint         property_id,
+                                     const GValue *value,
+                                     GParamSpec   *pspec)
+{
+  UDisksLinuxBlockZFS *block_zfs = UDISKS_LINUX_BLOCK_ZFS (object);
+
+  switch (property_id)
+    {
+    case PROP_MODULE:
+      g_assert (block_zfs->module == NULL);
+      block_zfs->module = UDISKS_LINUX_MODULE_ZFS (g_value_dup_object (value));
+      break;
+
+    case PROP_BLOCK_OBJECT:
+      g_assert (block_zfs->block_object == NULL);
+      /* we don't take reference to block_object */
+      block_zfs->block_object = g_value_get_object (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+    }
+}
+
+static void
+udisks_linux_block_zfs_finalize (GObject *object)
+{
+  UDisksLinuxBlockZFS *block_zfs = UDISKS_LINUX_BLOCK_ZFS (object);
+
+  /* we don't take reference to block_object */
+  g_object_unref (block_zfs->module);
+
+  if (G_OBJECT_CLASS (udisks_linux_block_zfs_parent_class))
+    G_OBJECT_CLASS (udisks_linux_block_zfs_parent_class)->finalize (object);
+}
+
+static void
+udisks_linux_block_zfs_class_init (UDisksLinuxBlockZFSClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+  gobject_class->get_property = udisks_linux_block_zfs_get_property;
+  gobject_class->set_property = udisks_linux_block_zfs_set_property;
+  gobject_class->finalize = udisks_linux_block_zfs_finalize;
+
+  /**
+   * UDisksLinuxBlockZFS:module:
+   *
+   * The #UDisksModule for the object.
+   */
+  g_object_class_install_property (gobject_class,
+                                   PROP_MODULE,
+                                   g_param_spec_object ("module",
+                                                        "Module",
+                                                        "The module for the object",
+                                                        UDISKS_TYPE_MODULE,
+                                                        G_PARAM_READABLE |
+                                                        G_PARAM_WRITABLE |
+                                                        G_PARAM_CONSTRUCT_ONLY |
+                                                        G_PARAM_STATIC_STRINGS));
+  /**
+   * UDisksLinuxBlockZFS:blockobject:
+   *
+   * The #UDisksLinuxBlockObject for the object.
+   */
+  g_object_class_install_property (gobject_class,
+                                   PROP_BLOCK_OBJECT,
+                                   g_param_spec_object ("blockobject",
+                                                        "Block object",
+                                                        "The block object for the interface",
+                                                        UDISKS_TYPE_LINUX_BLOCK_OBJECT,
+                                                        G_PARAM_READABLE |
+                                                        G_PARAM_WRITABLE |
+                                                        G_PARAM_CONSTRUCT_ONLY |
+                                                        G_PARAM_STATIC_STRINGS));
+}
+
+static void
+udisks_linux_block_zfs_init (UDisksLinuxBlockZFS *block_zfs)
+{
+  g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (block_zfs),
+                                       G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
+}
+
+/**
+ * udisks_linux_block_zfs_new:
+ * @module: A #UDisksLinuxModuleZFS.
+ * @block_object: A #UDisksLinuxBlockObject.
+ *
+ * Creates a new #UDisksLinuxBlockZFS instance.
+ *
+ * Returns: A new #UDisksLinuxBlockZFS. Free with g_object_unref().
+ */
+UDisksLinuxBlockZFS *
+udisks_linux_block_zfs_new (UDisksLinuxModuleZFS  *module,
+                            UDisksLinuxBlockObject *block_object)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_MODULE_ZFS (module), NULL);
+  g_return_val_if_fail (UDISKS_IS_LINUX_BLOCK_OBJECT (block_object), NULL);
+  return UDISKS_LINUX_BLOCK_ZFS (g_object_new (UDISKS_TYPE_LINUX_BLOCK_ZFS,
+                                               "module", UDISKS_MODULE (module),
+                                               "blockobject", block_object,
+                                               NULL));
+}
+
+/**
+ * udisks_linux_block_zfs_get_module:
+ * @block_zfs: A #UDisksLinuxBlockZFS.
+ *
+ * Gets the module used by @block_zfs.
+ *
+ * Returns: A #UDisksLinuxModuleZFS. Do not free, the object is owned by @block_zfs.
+ */
+UDisksLinuxModuleZFS *
+udisks_linux_block_zfs_get_module (UDisksLinuxBlockZFS *block_zfs)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_BLOCK_ZFS (block_zfs), NULL);
+  return block_zfs->module;
+}
+
+/**
+ * udisks_linux_block_zfs_update:
+ * @block_zfs: A #UDisksLinuxBlockZFS.
+ * @object: The enclosing #UDisksLinuxBlockObject instance.
+ *
+ * Updates the interface.
+ */
+static void
+udisks_linux_block_zfs_update (UDisksLinuxBlockZFS   *block_zfs,
+                               UDisksLinuxBlockObject *object)
+{
+  UDisksBlockZFS *iface = UDISKS_BLOCK_ZFS (block_zfs);
+  UDisksLinuxDevice *device;
+  const gchar *label;
+  UDisksLinuxPoolObjectZFS *pool_object;
+
+  device = udisks_linux_block_object_get_device (object);
+
+  /* ZFS pool members have the pool name in ID_FS_LABEL */
+  label = g_udev_device_get_property (device->udev_device, "ID_FS_LABEL");
+
+  if (label != NULL)
+    {
+      pool_object = udisks_linux_module_zfs_find_pool_object (block_zfs->module, label);
+      if (pool_object != NULL)
+        {
+          const gchar *pool_path;
+
+          pool_path = g_dbus_object_get_object_path (G_DBUS_OBJECT (pool_object));
+          udisks_block_zfs_set_pool (iface, pool_path);
+        }
+      else
+        {
+          udisks_block_zfs_set_pool (iface, "/");
+        }
+    }
+  else
+    {
+      udisks_block_zfs_set_pool (iface, "/");
+    }
+
+  g_dbus_interface_skeleton_flush (G_DBUS_INTERFACE_SKELETON (iface));
+  g_object_unref (device);
+}
+
+/* -------------------------------------------------------------------------- */
+
+static gboolean
+udisks_linux_block_zfs_module_object_process_uevent (UDisksModuleObject *module_object,
+                                                     UDisksUeventAction  action,
+                                                     UDisksLinuxDevice  *device,
+                                                     gboolean           *keep)
+{
+  UDisksLinuxBlockZFS *block_zfs = UDISKS_LINUX_BLOCK_ZFS (module_object);
+  const gchar *fs_type = NULL;
+
+  g_return_val_if_fail (UDISKS_IS_LINUX_BLOCK_ZFS (module_object), FALSE);
+
+  if (device == NULL)
+    return FALSE;
+
+  /* Check filesystem type from udev property. */
+  fs_type = g_udev_device_get_property (device->udev_device, "ID_FS_TYPE");
+  *keep = g_strcmp0 (fs_type, "zfs_member") == 0;
+  if (*keep)
+    {
+      udisks_linux_block_zfs_update (block_zfs, block_zfs->block_object);
+    }
+
+  return TRUE;
+}
+
+static void
+udisks_linux_block_zfs_module_object_iface_init (UDisksModuleObjectIface *iface)
+{
+  iface->process_uevent = udisks_linux_block_zfs_module_object_process_uevent;
+}

--- a/modules/zfs/udiskslinuxblockzfs.h
+++ b/modules/zfs/udiskslinuxblockzfs.h
@@ -1,0 +1,39 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __UDISKS_LINUX_BLOCK_ZFS_H__
+#define __UDISKS_LINUX_BLOCK_ZFS_H__
+
+#include <src/udisksdaemontypes.h>
+#include "udiskszfstypes.h"
+
+G_BEGIN_DECLS
+
+#define UDISKS_TYPE_LINUX_BLOCK_ZFS            (udisks_linux_block_zfs_get_type ())
+#define UDISKS_LINUX_BLOCK_ZFS(o)              (G_TYPE_CHECK_INSTANCE_CAST  ((o), UDISKS_TYPE_LINUX_BLOCK_ZFS, UDisksLinuxBlockZFS))
+#define UDISKS_IS_LINUX_BLOCK_ZFS(o)           (G_TYPE_CHECK_INSTANCE_TYPE  ((o), UDISKS_TYPE_LINUX_BLOCK_ZFS))
+
+GType                    udisks_linux_block_zfs_get_type   (void) G_GNUC_CONST;
+UDisksLinuxBlockZFS     *udisks_linux_block_zfs_new        (UDisksLinuxModuleZFS  *module,
+                                                            UDisksLinuxBlockObject *block_object);
+UDisksLinuxModuleZFS    *udisks_linux_block_zfs_get_module (UDisksLinuxBlockZFS   *block_zfs);
+
+G_END_DECLS
+
+#endif /* __UDISKS_LINUX_BLOCK_ZFS_H__ */

--- a/modules/zfs/udiskslinuxfilesystemzfs.c
+++ b/modules/zfs/udiskslinuxfilesystemzfs.c
@@ -1,0 +1,468 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+#include <string.h>
+
+#include <src/udisksdaemon.h>
+#include <src/udisksdaemonutil.h>
+#include <src/udiskslinuxblockobject.h>
+#include <src/udiskslinuxdevice.h>
+#include <src/udiskslogging.h>
+#include <src/udisksmodule.h>
+#include <src/udisksmoduleobject.h>
+
+#include "udiskszfstypes.h"
+#include "udiskslinuxmodulezfs.h"
+#include "udiskslinuxfilesystemzfs.h"
+#include "udiskslinuxpoolobjectzfs.h"
+
+/**
+ * SECTION:udiskslinuxfilesystemzfs
+ * @title: UDisksLinuxFilesystemZFS
+ * @short_description: Linux implementation of #UDisksFilesystemZFS
+ *
+ * This type provides an implementation of #UDisksFilesystemZFS interface
+ * on Linux.
+ */
+
+/**
+ * UDisksLinuxFilesystemZFS:
+ *
+ * The #UDisksLinuxFilesystemZFS structure contains only private data and
+ * should be only accessed using provided API.
+ */
+struct _UDisksLinuxFilesystemZFS {
+  UDisksFilesystemZFSSkeleton parent_instance;
+
+  UDisksLinuxModuleZFS *module;
+  UDisksLinuxBlockObject *block_object;
+};
+
+struct _UDisksLinuxFilesystemZFSClass {
+  UDisksFilesystemZFSSkeletonClass parent_class;
+};
+
+enum
+{
+  PROP_0,
+  PROP_MODULE,
+  PROP_BLOCK_OBJECT,
+  N_PROPERTIES
+};
+
+static void udisks_linux_filesystem_zfs_module_object_iface_init (UDisksModuleObjectIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (UDisksLinuxFilesystemZFS, udisks_linux_filesystem_zfs, UDISKS_TYPE_FILESYSTEM_ZFS_SKELETON,
+                         G_IMPLEMENT_INTERFACE (UDISKS_TYPE_FILESYSTEM_ZFS, NULL)
+                         G_IMPLEMENT_INTERFACE (UDISKS_TYPE_MODULE_OBJECT, udisks_linux_filesystem_zfs_module_object_iface_init));
+
+static void
+udisks_linux_filesystem_zfs_get_property (GObject    *object,
+                                          guint       property_id,
+                                          GValue     *value,
+                                          GParamSpec *pspec)
+{
+  UDisksLinuxFilesystemZFS *fs_zfs = UDISKS_LINUX_FILESYSTEM_ZFS (object);
+
+  switch (property_id)
+    {
+    case PROP_MODULE:
+      g_value_set_object (value, UDISKS_MODULE (udisks_linux_filesystem_zfs_get_module (fs_zfs)));
+      break;
+
+    case PROP_BLOCK_OBJECT:
+      g_value_set_object (value, fs_zfs->block_object);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+    }
+}
+
+static void
+udisks_linux_filesystem_zfs_set_property (GObject      *object,
+                                          guint         property_id,
+                                          const GValue *value,
+                                          GParamSpec   *pspec)
+{
+  UDisksLinuxFilesystemZFS *fs_zfs = UDISKS_LINUX_FILESYSTEM_ZFS (object);
+
+  switch (property_id)
+    {
+    case PROP_MODULE:
+      g_assert (fs_zfs->module == NULL);
+      fs_zfs->module = UDISKS_LINUX_MODULE_ZFS (g_value_dup_object (value));
+      break;
+
+    case PROP_BLOCK_OBJECT:
+      g_assert (fs_zfs->block_object == NULL);
+      /* we don't take reference to block_object */
+      fs_zfs->block_object = g_value_get_object (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+    }
+}
+
+static void
+udisks_linux_filesystem_zfs_finalize (GObject *object)
+{
+  UDisksLinuxFilesystemZFS *fs_zfs = UDISKS_LINUX_FILESYSTEM_ZFS (object);
+
+  /* we don't take reference to block_object */
+  g_object_unref (fs_zfs->module);
+
+  if (G_OBJECT_CLASS (udisks_linux_filesystem_zfs_parent_class))
+    G_OBJECT_CLASS (udisks_linux_filesystem_zfs_parent_class)->finalize (object);
+}
+
+static void
+udisks_linux_filesystem_zfs_class_init (UDisksLinuxFilesystemZFSClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+  gobject_class->get_property = udisks_linux_filesystem_zfs_get_property;
+  gobject_class->set_property = udisks_linux_filesystem_zfs_set_property;
+  gobject_class->finalize = udisks_linux_filesystem_zfs_finalize;
+
+  /**
+   * UDisksLinuxFilesystemZFS:module:
+   *
+   * The #UDisksModule for the object.
+   */
+  g_object_class_install_property (gobject_class,
+                                   PROP_MODULE,
+                                   g_param_spec_object ("module",
+                                                        "Module",
+                                                        "The module for the object",
+                                                        UDISKS_TYPE_MODULE,
+                                                        G_PARAM_READABLE |
+                                                        G_PARAM_WRITABLE |
+                                                        G_PARAM_CONSTRUCT_ONLY |
+                                                        G_PARAM_STATIC_STRINGS));
+  /**
+   * UDisksLinuxFilesystemZFS:blockobject:
+   *
+   * The #UDisksLinuxBlockObject for the object.
+   */
+  g_object_class_install_property (gobject_class,
+                                   PROP_BLOCK_OBJECT,
+                                   g_param_spec_object ("blockobject",
+                                                        "Block object",
+                                                        "The block object for the interface",
+                                                        UDISKS_TYPE_LINUX_BLOCK_OBJECT,
+                                                        G_PARAM_READABLE |
+                                                        G_PARAM_WRITABLE |
+                                                        G_PARAM_CONSTRUCT_ONLY |
+                                                        G_PARAM_STATIC_STRINGS));
+}
+
+static void
+udisks_linux_filesystem_zfs_init (UDisksLinuxFilesystemZFS *fs_zfs)
+{
+  g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (fs_zfs),
+                                       G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
+}
+
+/**
+ * udisks_linux_filesystem_zfs_new:
+ * @module: A #UDisksLinuxModuleZFS.
+ * @block_object: A #UDisksLinuxBlockObject.
+ *
+ * Creates a new #UDisksLinuxFilesystemZFS instance.
+ *
+ * Returns: A new #UDisksLinuxFilesystemZFS. Free with g_object_unref().
+ */
+UDisksLinuxFilesystemZFS *
+udisks_linux_filesystem_zfs_new (UDisksLinuxModuleZFS  *module,
+                                 UDisksLinuxBlockObject *block_object)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_MODULE_ZFS (module), NULL);
+  g_return_val_if_fail (UDISKS_IS_LINUX_BLOCK_OBJECT (block_object), NULL);
+  return UDISKS_LINUX_FILESYSTEM_ZFS (g_object_new (UDISKS_TYPE_LINUX_FILESYSTEM_ZFS,
+                                                    "module", UDISKS_MODULE (module),
+                                                    "blockobject", block_object,
+                                                    NULL));
+}
+
+/**
+ * udisks_linux_filesystem_zfs_get_module:
+ * @fs_zfs: A #UDisksLinuxFilesystemZFS.
+ *
+ * Gets the module used by @fs_zfs.
+ *
+ * Returns: A #UDisksLinuxModuleZFS. Do not free, the object is owned by @fs_zfs.
+ */
+UDisksLinuxModuleZFS *
+udisks_linux_filesystem_zfs_get_module (UDisksLinuxFilesystemZFS *fs_zfs)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_FILESYSTEM_ZFS (fs_zfs), NULL);
+  return fs_zfs->module;
+}
+
+/**
+ * udisks_linux_filesystem_zfs_update:
+ * @fs_zfs: A #UDisksLinuxFilesystemZFS.
+ * @object: The enclosing #UDisksLinuxBlockObject instance.
+ *
+ * Updates the interface properties from the block device.
+ *
+ * For zvol block devices, the device path is typically /dev/zd* and the
+ * DM_NAME or device symlinks reveal the pool and dataset name.
+ * We also use ID_FS_LABEL and ID_FS_UUID_SUB udev properties when available.
+ */
+static void
+udisks_linux_filesystem_zfs_update (UDisksLinuxFilesystemZFS *fs_zfs,
+                                    UDisksLinuxBlockObject   *object)
+{
+  UDisksFilesystemZFS *iface = UDISKS_FILESYSTEM_ZFS (fs_zfs);
+  UDisksLinuxDevice *device;
+  const gchar *dev_file;
+  const gchar *pool_name = NULL;
+  const gchar *dataset_name = NULL;
+  UDisksLinuxPoolObjectZFS *pool_object;
+
+  device = udisks_linux_block_object_get_device (object);
+  dev_file = g_udev_device_get_device_file (device->udev_device);
+
+  /* Try to extract the pool and dataset name.
+   *
+   * For zvol block devices, udev typically sets DM_NAME to "pool/volname"
+   * or the device appears under /dev/zvol/pool/volname.
+   * We also check ID_FS_LABEL which on some setups contains the pool name.
+   */
+
+  /* Check DM_NAME first (e.g. "tank-zvol0" or "tank/zvol0") */
+  pool_name = g_udev_device_get_property (device->udev_device, "DM_NAME");
+  if (pool_name != NULL && strchr (pool_name, '/') != NULL)
+    {
+      /* DM_NAME has format "pool/dataset" */
+      gchar **parts = g_strsplit (pool_name, "/", 2);
+      udisks_filesystem_zfs_set_pool_name (iface, parts[0]);
+      udisks_filesystem_zfs_set_dataset_name (iface, pool_name);
+      pool_name = parts[0];
+
+      pool_object = udisks_linux_module_zfs_find_pool_object (fs_zfs->module, pool_name);
+      if (pool_object != NULL)
+        {
+          const gchar *pool_path;
+
+          pool_path = g_dbus_object_get_object_path (G_DBUS_OBJECT (pool_object));
+          udisks_filesystem_zfs_set_pool (iface, pool_path);
+        }
+      else
+        {
+          udisks_filesystem_zfs_set_pool (iface, "/");
+        }
+
+      g_strfreev (parts);
+    }
+  else
+    {
+      /* Try /dev/zvol symlink path: the device path encodes pool/dataset */
+      const gchar *zvol_prefix = "/dev/zvol/";
+
+      if (dev_file != NULL && g_str_has_prefix (dev_file, zvol_prefix))
+        {
+          const gchar *zvol_path = dev_file + strlen (zvol_prefix);
+          const gchar *slash;
+
+          slash = strchr (zvol_path, '/');
+          if (slash != NULL)
+            {
+              gchar *pname = g_strndup (zvol_path, slash - zvol_path);
+              udisks_filesystem_zfs_set_pool_name (iface, pname);
+              udisks_filesystem_zfs_set_dataset_name (iface, zvol_path);
+
+              pool_object = udisks_linux_module_zfs_find_pool_object (fs_zfs->module, pname);
+              if (pool_object != NULL)
+                {
+                  const gchar *pool_path;
+
+                  pool_path = g_dbus_object_get_object_path (G_DBUS_OBJECT (pool_object));
+                  udisks_filesystem_zfs_set_pool (iface, pool_path);
+                }
+              else
+                {
+                  udisks_filesystem_zfs_set_pool (iface, "/");
+                }
+
+              g_free (pname);
+            }
+          else
+            {
+              /* No slash: the path is just the pool name */
+              udisks_filesystem_zfs_set_pool_name (iface, zvol_path);
+              udisks_filesystem_zfs_set_dataset_name (iface, zvol_path);
+
+              pool_object = udisks_linux_module_zfs_find_pool_object (fs_zfs->module, zvol_path);
+              if (pool_object != NULL)
+                {
+                  const gchar *pool_path;
+
+                  pool_path = g_dbus_object_get_object_path (G_DBUS_OBJECT (pool_object));
+                  udisks_filesystem_zfs_set_pool (iface, pool_path);
+                }
+              else
+                {
+                  udisks_filesystem_zfs_set_pool (iface, "/");
+                }
+            }
+        }
+      else
+        {
+          /* Fallback: try ID_FS_LABEL for the pool name */
+          dataset_name = g_udev_device_get_property (device->udev_device, "ID_FS_LABEL");
+          if (dataset_name != NULL)
+            {
+              const gchar *slash = strchr (dataset_name, '/');
+              if (slash != NULL)
+                {
+                  gchar *pname = g_strndup (dataset_name, slash - dataset_name);
+                  udisks_filesystem_zfs_set_pool_name (iface, pname);
+                  udisks_filesystem_zfs_set_dataset_name (iface, dataset_name);
+
+                  pool_object = udisks_linux_module_zfs_find_pool_object (fs_zfs->module, pname);
+                  if (pool_object != NULL)
+                    {
+                      const gchar *pool_path;
+
+                      pool_path = g_dbus_object_get_object_path (G_DBUS_OBJECT (pool_object));
+                      udisks_filesystem_zfs_set_pool (iface, pool_path);
+                    }
+                  else
+                    {
+                      udisks_filesystem_zfs_set_pool (iface, "/");
+                    }
+
+                  g_free (pname);
+                }
+              else
+                {
+                  udisks_filesystem_zfs_set_pool_name (iface, dataset_name);
+                  udisks_filesystem_zfs_set_dataset_name (iface, dataset_name);
+
+                  pool_object = udisks_linux_module_zfs_find_pool_object (fs_zfs->module, dataset_name);
+                  if (pool_object != NULL)
+                    {
+                      const gchar *pool_path;
+
+                      pool_path = g_dbus_object_get_object_path (G_DBUS_OBJECT (pool_object));
+                      udisks_filesystem_zfs_set_pool (iface, pool_path);
+                    }
+                  else
+                    {
+                      udisks_filesystem_zfs_set_pool (iface, "/");
+                    }
+                }
+            }
+          else
+            {
+              udisks_filesystem_zfs_set_pool (iface, "/");
+              udisks_filesystem_zfs_set_pool_name (iface, "");
+              udisks_filesystem_zfs_set_dataset_name (iface, "");
+            }
+        }
+    }
+
+  g_dbus_interface_skeleton_flush (G_DBUS_INTERFACE_SKELETON (iface));
+  g_object_unref (device);
+}
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * is_zvol_device:
+ * @device: A #UDisksLinuxDevice.
+ *
+ * Checks whether the device is a ZFS zvol block device.
+ *
+ * Zvol devices are identified by:
+ * - Device path starting with /dev/zd (zvol device nodes)
+ * - DM_NAME containing a slash (pool/dataset format)
+ * - Symlinks under /dev/zvol/
+ *
+ * Returns: %TRUE if the device is a zvol.
+ */
+static gboolean
+is_zvol_device (UDisksLinuxDevice *device)
+{
+  const gchar *dev_file;
+  const gchar *dm_uuid;
+  const gchar * const *symlinks;
+
+  dev_file = g_udev_device_get_device_file (device->udev_device);
+
+  /* zvol block devices use /dev/zd* device nodes */
+  if (dev_file != NULL && g_str_has_prefix (dev_file, "/dev/zd"))
+    return TRUE;
+
+  /* Check for ZFS DM UUID (zvols created via device-mapper) */
+  dm_uuid = g_udev_device_get_property (device->udev_device, "DM_UUID");
+  if (dm_uuid != NULL && g_str_has_prefix (dm_uuid, "zvol-"))
+    return TRUE;
+
+  /* Check for /dev/zvol/ symlinks */
+  symlinks = g_udev_device_get_device_file_symlinks (device->udev_device);
+  if (symlinks != NULL)
+    {
+      for (const gchar * const *s = symlinks; *s != NULL; s++)
+        {
+          if (g_str_has_prefix (*s, "/dev/zvol/"))
+            return TRUE;
+        }
+    }
+
+  return FALSE;
+}
+
+static gboolean
+udisks_linux_filesystem_zfs_module_object_process_uevent (UDisksModuleObject *module_object,
+                                                          UDisksUeventAction  action,
+                                                          UDisksLinuxDevice  *device,
+                                                          gboolean           *keep)
+{
+  UDisksLinuxFilesystemZFS *fs_zfs = UDISKS_LINUX_FILESYSTEM_ZFS (module_object);
+
+  g_return_val_if_fail (UDISKS_IS_LINUX_FILESYSTEM_ZFS (module_object), FALSE);
+
+  if (device == NULL)
+    return FALSE;
+
+  /* Keep the interface as long as the device is still a zvol */
+  *keep = is_zvol_device (device);
+  if (*keep)
+    {
+      udisks_linux_filesystem_zfs_update (fs_zfs, fs_zfs->block_object);
+    }
+
+  return TRUE;
+}
+
+static void
+udisks_linux_filesystem_zfs_module_object_iface_init (UDisksModuleObjectIface *iface)
+{
+  iface->process_uevent = udisks_linux_filesystem_zfs_module_object_process_uevent;
+}

--- a/modules/zfs/udiskslinuxfilesystemzfs.h
+++ b/modules/zfs/udiskslinuxfilesystemzfs.h
@@ -1,0 +1,39 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __UDISKS_LINUX_FILESYSTEM_ZFS_H__
+#define __UDISKS_LINUX_FILESYSTEM_ZFS_H__
+
+#include <src/udisksdaemontypes.h>
+#include "udiskszfstypes.h"
+
+G_BEGIN_DECLS
+
+#define UDISKS_TYPE_LINUX_FILESYSTEM_ZFS            (udisks_linux_filesystem_zfs_get_type ())
+#define UDISKS_LINUX_FILESYSTEM_ZFS(o)              (G_TYPE_CHECK_INSTANCE_CAST  ((o), UDISKS_TYPE_LINUX_FILESYSTEM_ZFS, UDisksLinuxFilesystemZFS))
+#define UDISKS_IS_LINUX_FILESYSTEM_ZFS(o)           (G_TYPE_CHECK_INSTANCE_TYPE  ((o), UDISKS_TYPE_LINUX_FILESYSTEM_ZFS))
+
+GType                       udisks_linux_filesystem_zfs_get_type   (void) G_GNUC_CONST;
+UDisksLinuxFilesystemZFS   *udisks_linux_filesystem_zfs_new        (UDisksLinuxModuleZFS  *module,
+                                                                    UDisksLinuxBlockObject *block_object);
+UDisksLinuxModuleZFS       *udisks_linux_filesystem_zfs_get_module (UDisksLinuxFilesystemZFS *fs_zfs);
+
+G_END_DECLS
+
+#endif /* __UDISKS_LINUX_FILESYSTEM_ZFS_H__ */

--- a/modules/zfs/udiskslinuxmodulezfs.c
+++ b/modules/zfs/udiskslinuxmodulezfs.c
@@ -30,10 +30,14 @@
 #include <src/udisksmodule.h>
 #include <src/udisksmoduleobject.h>
 
+#include <src/udiskslinuxblockobject.h>
+
 #include "udiskszfstypes.h"
 #include "udiskslinuxmodulezfs.h"
 #include "udiskslinuxmanagerzfs.h"
 #include "udiskslinuxpoolobjectzfs.h"
+#include "udiskslinuxblockzfs.h"
+#include "udiskslinuxfilesystemzfs.h"
 
 /**
  * SECTION:udiskslinuxmodulezfs
@@ -436,6 +440,96 @@ udisks_linux_module_zfs_handle_uevent (UDisksModule      *module,
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+static gboolean
+is_zvol_device (UDisksLinuxDevice *device)
+{
+  const gchar *dev_file;
+  const gchar *dm_uuid;
+  const gchar * const *symlinks;
+
+  dev_file = g_udev_device_get_device_file (device->udev_device);
+
+  /* zvol block devices use /dev/zd* device nodes */
+  if (dev_file != NULL && g_str_has_prefix (dev_file, "/dev/zd"))
+    return TRUE;
+
+  /* Check for ZFS DM UUID (zvols created via device-mapper) */
+  dm_uuid = g_udev_device_get_property (device->udev_device, "DM_UUID");
+  if (dm_uuid != NULL && g_str_has_prefix (dm_uuid, "zvol-"))
+    return TRUE;
+
+  /* Check for /dev/zvol/ symlinks */
+  symlinks = g_udev_device_get_device_file_symlinks (device->udev_device);
+  if (symlinks != NULL)
+    {
+      for (const gchar * const *s = symlinks; *s != NULL; s++)
+        {
+          if (g_str_has_prefix (*s, "/dev/zvol/"))
+            return TRUE;
+        }
+    }
+
+  return FALSE;
+}
+
+static GType *
+udisks_linux_module_zfs_get_block_object_interface_types (UDisksModule *module)
+{
+  static GType block_object_interface_types[3];
+
+  g_return_val_if_fail (UDISKS_IS_LINUX_MODULE_ZFS (module), NULL);
+
+  if (g_once_init_enter (&block_object_interface_types[0]))
+    {
+      block_object_interface_types[1] = UDISKS_TYPE_LINUX_FILESYSTEM_ZFS;
+      g_once_init_leave (&block_object_interface_types[0], UDISKS_TYPE_LINUX_BLOCK_ZFS);
+    }
+
+  return block_object_interface_types;
+}
+
+static GDBusInterfaceSkeleton *
+udisks_linux_module_zfs_new_block_object_interface (UDisksModule           *module,
+                                                    UDisksLinuxBlockObject *object,
+                                                    GType                   interface_type)
+{
+  GDBusInterfaceSkeleton *interface = NULL;
+  UDisksLinuxDevice *device;
+  const gchar *fs_type;
+
+  g_return_val_if_fail (UDISKS_IS_LINUX_MODULE_ZFS (module), NULL);
+
+  if (interface_type == UDISKS_TYPE_LINUX_BLOCK_ZFS)
+    {
+      /* Attach Block.ZFS to devices that are ZFS pool members */
+      device = udisks_linux_block_object_get_device (UDISKS_LINUX_BLOCK_OBJECT (object));
+      fs_type = g_udev_device_get_property (device->udev_device, "ID_FS_TYPE");
+      if (g_strcmp0 (fs_type, "zfs_member") == 0)
+        {
+          interface = G_DBUS_INTERFACE_SKELETON (udisks_linux_block_zfs_new (UDISKS_LINUX_MODULE_ZFS (module), object));
+        }
+      g_object_unref (device);
+    }
+  else if (interface_type == UDISKS_TYPE_LINUX_FILESYSTEM_ZFS)
+    {
+      /* Attach Filesystem.ZFS to zvol block devices */
+      device = udisks_linux_block_object_get_device (UDISKS_LINUX_BLOCK_OBJECT (object));
+      if (is_zvol_device (device))
+        {
+          interface = G_DBUS_INTERFACE_SKELETON (udisks_linux_filesystem_zfs_new (UDISKS_LINUX_MODULE_ZFS (module), object));
+        }
+      g_object_unref (device);
+    }
+  else
+    {
+      udisks_error ("ZFS: invalid block object interface type");
+    }
+
+  return interface;
+}
+
+/* ---------------------------------------------------------------------------------------------------- */
+
 static void
 udisks_linux_module_zfs_class_init (UDisksLinuxModuleZFSClass *klass)
 {
@@ -449,4 +543,6 @@ udisks_linux_module_zfs_class_init (UDisksLinuxModuleZFSClass *klass)
   module_class = UDISKS_MODULE_CLASS (klass);
   module_class->new_manager = udisks_linux_module_zfs_new_manager;
   module_class->handle_uevent = udisks_linux_module_zfs_handle_uevent;
+  module_class->get_block_object_interface_types = udisks_linux_module_zfs_get_block_object_interface_types;
+  module_class->new_block_object_interface = udisks_linux_module_zfs_new_block_object_interface;
 }

--- a/modules/zfs/udiskszfstypes.h
+++ b/modules/zfs/udiskszfstypes.h
@@ -34,4 +34,10 @@ typedef struct _UDisksLinuxManagerZFSClass   UDisksLinuxManagerZFSClass;
 typedef struct _UDisksLinuxPoolObjectZFS        UDisksLinuxPoolObjectZFS;
 typedef struct _UDisksLinuxPoolObjectZFSClass   UDisksLinuxPoolObjectZFSClass;
 
+typedef struct _UDisksLinuxBlockZFS        UDisksLinuxBlockZFS;
+typedef struct _UDisksLinuxBlockZFSClass   UDisksLinuxBlockZFSClass;
+
+typedef struct _UDisksLinuxFilesystemZFS        UDisksLinuxFilesystemZFS;
+typedef struct _UDisksLinuxFilesystemZFSClass   UDisksLinuxFilesystemZFSClass;
+
 #endif /* __UDISKS_ZFS_TYPES_H__ */


### PR DESCRIPTION
## Summary
- Block.ZFS attaches to zfs_member devices with Pool object path
- Filesystem.ZFS attaches to zvol block devices with pool/dataset info
- Module overrides for get_block_object_interface_types and new_block_object_interface
- Both implement UDisksModuleObject for uevent-driven lifecycle

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)