### PR TITLE
U9: Add ZFS property allowlist security hardening

### DIFF
--- a/modules/zfs/Makefile.am
+++ b/modules/zfs/Makefile.am
@@ -49,6 +49,8 @@ libudisks2_zfs_la_SOURCES =                                                    \
 	udiskslinuxblockzfs.c                                                  \
 	udiskslinuxfilesystemzfs.h                                             \
 	udiskslinuxfilesystemzfs.c                                             \
+	udiskszfsdaemonutil.h                                                  \
+	udiskszfsdaemonutil.c                                                  \
 	udiskszfstypes.h                                                       \
 	$(NULL)
 

--- a/modules/zfs/udiskslinuxpoolobjectzfs.c
+++ b/modules/zfs/udiskslinuxpoolobjectzfs.c
@@ -29,6 +29,7 @@
 #include <src/udisksdaemonutil.h>
 
 #include "udiskszfstypes.h"
+#include "udiskszfsdaemonutil.h"
 #include "udiskslinuxpoolobjectzfs.h"
 #include "udiskslinuxmodulezfs.h"
 
@@ -574,15 +575,10 @@ handle_set_property (UDisksZFSPool         *iface,
   UDisksLinuxPoolObjectZFS *object = UDISKS_LINUX_POOL_OBJECT_ZFS (user_data);
   UDisksDaemon *daemon;
   GError *error = NULL;
+  GError *prop_error = NULL;
+  const gchar *action_id;
 
   daemon = udisks_module_get_daemon (UDISKS_MODULE (object->module));
-
-  UDISKS_DAEMON_CHECK_AUTHORIZATION (daemon,
-                                     UDISKS_OBJECT (object),
-                                     ZFS_POLICY_ACTION_ID,
-                                     arg_options,
-                                     N_("Authentication is required to set a ZFS pool property"),
-                                     invocation);
 
   if (arg_name == NULL || strlen (arg_name) == 0)
     {
@@ -592,6 +588,26 @@ handle_set_property (UDisksZFSPool         *iface,
                                              "Property name must not be empty");
       goto out;
     }
+
+  /* Check property against the allowlist */
+  if (!udisks_zfs_property_is_allowed (arg_name, &prop_error))
+    {
+      g_dbus_method_invocation_take_error (invocation, prop_error);
+      goto out;
+    }
+
+  /* Security-sensitive properties require elevated authorization */
+  if (udisks_zfs_property_is_safe (arg_name, NULL))
+    action_id = ZFS_POLICY_ACTION_ID;
+  else
+    action_id = ZFS_POLICY_ACTION_ID_DESTROY;
+
+  UDISKS_DAEMON_CHECK_AUTHORIZATION (daemon,
+                                     UDISKS_OBJECT (object),
+                                     action_id,
+                                     arg_options,
+                                     N_("Authentication is required to set a ZFS pool property"),
+                                     invocation);
 
   if (!bd_zfs_pool_set_property (object->name, arg_name, arg_value, &error))
     {
@@ -938,6 +954,11 @@ handle_mount_dataset (UDisksZFSPool         *iface,
                                      N_("Authentication is required to mount a ZFS dataset"),
                                      invocation);
 
+  /* TODO: When the UDisks mount options framework (udiskslinuxmountoptions.c)
+   * is integrated with the ZFS module, enforce nodev,nosuid defaults here.
+   * This requires mapping ZFS mount semantics to the core options framework
+   * and is deferred to a future change. */
+
   if (!bd_zfs_dataset_mount (arg_name, NULL, NULL, &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
@@ -1142,16 +1163,10 @@ handle_set_dataset_property (UDisksZFSPool         *iface,
   UDisksLinuxPoolObjectZFS *object = UDISKS_LINUX_POOL_OBJECT_ZFS (user_data);
   UDisksDaemon *daemon;
   GError *error = NULL;
+  GError *prop_error = NULL;
+  const gchar *action_id;
 
   daemon = udisks_module_get_daemon (UDISKS_MODULE (object->module));
-
-  /* Policy check — security-sensitive property allowlist deferred to U9 */
-  UDISKS_DAEMON_CHECK_AUTHORIZATION (daemon,
-                                     UDISKS_OBJECT (object),
-                                     ZFS_POLICY_ACTION_ID,
-                                     arg_options,
-                                     N_("Authentication is required to set a ZFS dataset property"),
-                                     invocation);
 
   if (arg_property == NULL || strlen (arg_property) == 0)
     {
@@ -1161,6 +1176,26 @@ handle_set_dataset_property (UDisksZFSPool         *iface,
                                              "Property name must not be empty");
       goto out;
     }
+
+  /* Check property against the allowlist */
+  if (!udisks_zfs_property_is_allowed (arg_property, &prop_error))
+    {
+      g_dbus_method_invocation_take_error (invocation, prop_error);
+      goto out;
+    }
+
+  /* Security-sensitive properties require elevated authorization */
+  if (udisks_zfs_property_is_safe (arg_property, NULL))
+    action_id = ZFS_POLICY_ACTION_ID;
+  else
+    action_id = ZFS_POLICY_ACTION_ID_DESTROY;
+
+  UDISKS_DAEMON_CHECK_AUTHORIZATION (daemon,
+                                     UDISKS_OBJECT (object),
+                                     action_id,
+                                     arg_options,
+                                     N_("Authentication is required to set a ZFS dataset property"),
+                                     invocation);
 
   if (!bd_zfs_dataset_set_property (arg_dataset, arg_property, arg_value, &error))
     {

--- a/modules/zfs/udiskszfsdaemonutil.c
+++ b/modules/zfs/udiskszfsdaemonutil.c
@@ -1,0 +1,195 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+
+#include <string.h>
+
+#include <udisks/udiskserror.h>
+
+#include "udiskszfsdaemonutil.h"
+
+/**
+ * SECTION:udiskszfsdaemonutil
+ * @title: ZFS Daemon Utilities
+ * @short_description: Property allowlist enforcement for ZFS operations
+ *
+ * Utility functions that enforce a property allowlist for ZFS pool and
+ * dataset property modifications.  Properties are divided into two tiers:
+ *
+ *  - **Safe properties** require only `manage-zfs` polkit authorization.
+ *  - **Security-sensitive properties** require the stronger
+ *    `manage-zfs-destroy` authorization because they can alter mount
+ *    behaviour, enable setuid execution, or change sharing/ACL semantics.
+ *
+ * User properties (those containing a colon, e.g. `user:backup-tag`) are
+ * always treated as safe.
+ */
+
+/* Properties that are safe to set with manage-zfs authorization. */
+static const gchar * const safe_properties[] =
+{
+  "compression",
+  "atime",
+  "relatime",
+  "recordsize",
+  "quota",
+  "reservation",
+  "refquota",
+  "refreservation",
+  "copies",
+  "logbias",
+  "primarycache",
+  "secondarycache",
+  "snapdir",
+  "sync",
+  "dedup",
+  "checksum",
+  "redundant_metadata",
+  "dnodesize",
+  "special_small_blocks",
+  NULL
+};
+
+/* Properties that are security-sensitive and require manage-zfs-destroy. */
+static const gchar * const sensitive_properties[] =
+{
+  "mountpoint",
+  "exec",
+  "setuid",
+  "devices",
+  "sharenfs",
+  "sharesmb",
+  "canmount",
+  "overlay",
+  "acltype",
+  "xattr",
+  NULL
+};
+
+/**
+ * is_user_property:
+ * @property: A ZFS property name.
+ *
+ * User properties always contain a colon (e.g. "user:tag", "com.example:key").
+ *
+ * Returns: %TRUE if @property is a user property.
+ */
+static gboolean
+is_user_property (const gchar *property)
+{
+  return (strchr (property, ':') != NULL);
+}
+
+/**
+ * udisks_zfs_property_is_safe:
+ * @property: A ZFS property name.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Checks whether @property is in the "safe" tier of the allowlist.
+ * Safe properties only require `manage-zfs` polkit authorization.
+ *
+ * User properties (containing a colon) are always considered safe.
+ *
+ * Returns: %TRUE if @property is a safe property, %FALSE if it is
+ *   security-sensitive or not in any allowlist.  When the property is
+ *   security-sensitive (but still allowed), %FALSE is returned and
+ *   @error is not set.  When the property is not in any allowlist,
+ *   %FALSE is returned and @error is set.
+ */
+gboolean
+udisks_zfs_property_is_safe (const gchar  *property,
+                              GError      **error)
+{
+  guint i;
+
+  g_return_val_if_fail (property != NULL, FALSE);
+
+  /* User properties (containing ':') are always safe */
+  if (is_user_property (property))
+    return TRUE;
+
+  for (i = 0; safe_properties[i] != NULL; i++)
+    {
+      if (g_strcmp0 (property, safe_properties[i]) == 0)
+        return TRUE;
+    }
+
+  /* Check if it is at least in the sensitive list — if so it is allowed
+   * but not safe (caller should use manage-zfs-destroy). */
+  for (i = 0; sensitive_properties[i] != NULL; i++)
+    {
+      if (g_strcmp0 (property, sensitive_properties[i]) == 0)
+        return FALSE;
+    }
+
+  /* Not in any allowlist */
+  if (error != NULL)
+    g_set_error (error,
+                 UDISKS_ERROR,
+                 UDISKS_ERROR_OPTION_NOT_PERMITTED,
+                 "Property '%s' is not in the ZFS property allowlist",
+                 property);
+
+  return FALSE;
+}
+
+/**
+ * udisks_zfs_property_is_allowed:
+ * @property: A ZFS property name.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Checks whether @property is permitted at all (either safe or
+ * security-sensitive).
+ *
+ * Returns: %TRUE if @property is in the allowlist (safe or sensitive),
+ *   %FALSE if it is unknown/disallowed (with @error set).
+ */
+gboolean
+udisks_zfs_property_is_allowed (const gchar  *property,
+                                 GError      **error)
+{
+  guint i;
+
+  g_return_val_if_fail (property != NULL, FALSE);
+
+  /* User properties are always allowed */
+  if (is_user_property (property))
+    return TRUE;
+
+  for (i = 0; safe_properties[i] != NULL; i++)
+    {
+      if (g_strcmp0 (property, safe_properties[i]) == 0)
+        return TRUE;
+    }
+
+  for (i = 0; sensitive_properties[i] != NULL; i++)
+    {
+      if (g_strcmp0 (property, sensitive_properties[i]) == 0)
+        return TRUE;
+    }
+
+  g_set_error (error,
+               UDISKS_ERROR,
+               UDISKS_ERROR_OPTION_NOT_PERMITTED,
+               "Property '%s' is not in the ZFS property allowlist",
+               property);
+
+  return FALSE;
+}

--- a/modules/zfs/udiskszfsdaemonutil.h
+++ b/modules/zfs/udiskszfsdaemonutil.h
@@ -1,0 +1,35 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2024 Razvan Cojocaru <rzvncj@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __UDISKS_ZFS_DAEMON_UTIL_H__
+#define __UDISKS_ZFS_DAEMON_UTIL_H__
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+gboolean udisks_zfs_property_is_safe    (const gchar  *property,
+                                          GError      **error);
+
+gboolean udisks_zfs_property_is_allowed (const gchar  *property,
+                                          GError      **error);
+
+G_END_DECLS
+
+#endif /* __UDISKS_ZFS_DAEMON_UTIL_H__ */


### PR DESCRIPTION
## Summary
- Property allowlist: 19 safe + 10 sensitive properties
- Safe properties: manage-zfs polkit level
- Sensitive properties (mountpoint, exec, setuid, devices, etc.): manage-zfs-destroy level
- User properties (containing ':') always allowed as safe
- Unknown properties rejected with OPTION_NOT_PERMITTED
- Applied to both pool SetProperty and dataset SetDatasetProperty

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)