### PR TITLE
U-S6-1: Build, docs, translations, encryption validation, stripe alignment

### DIFF
--- a/modules/zfs/udiskslinuxblockzfs.c
+++ b/modules/zfs/udiskslinuxblockzfs.c
@@ -19,7 +19,7 @@
 
 #include "config.h"
 
-#include <glib/gi18n.h>
+#include <glib/gi18n-lib.h>
 #include <string.h>
 
 #include <src/udisksdaemon.h>

--- a/modules/zfs/udiskslinuxfilesystemzfs.c
+++ b/modules/zfs/udiskslinuxfilesystemzfs.c
@@ -19,7 +19,7 @@
 
 #include "config.h"
 
-#include <glib/gi18n.h>
+#include <glib/gi18n-lib.h>
 #include <string.h>
 
 #include <src/udisksdaemon.h>

--- a/modules/zfs/udiskslinuxmanagerzfs.c
+++ b/modules/zfs/udiskslinuxmanagerzfs.c
@@ -327,26 +327,31 @@ handle_pool_create (UDisksManagerZFS      *_manager,
       goto out;
     }
 
-  /* ZFS pool names must start with a letter, and contain only
-   * alphanumeric characters, hyphens, underscores, and periods.
-   * Reserved prefixes (mirror, raidz, draid, spare) are disallowed. */
+  /* ZFS pool names must start with a letter, contain only
+   * alphanumeric characters plus _ - . :, be at most 239 characters,
+   * and not begin with a reserved prefix (mirror, raidz, draid, spare,
+   * log).  These rules mirror what libblockdev/zfs enforce. */
   {
     const gchar *p;
     gboolean valid = TRUE;
 
-    if (!g_ascii_isalpha (arg_name[0]))
+    if (strlen (arg_name) > 239)
+      valid = FALSE;
+
+    if (valid && !g_ascii_isalpha (arg_name[0]))
       valid = FALSE;
 
     for (p = arg_name; valid && *p != '\0'; p++)
       {
-        if (!g_ascii_isalnum (*p) && *p != '-' && *p != '_' && *p != '.')
+        if (!g_ascii_isalnum (*p) && *p != '-' && *p != '_' && *p != '.' && *p != ':')
           valid = FALSE;
       }
 
     if (valid && (g_str_has_prefix (arg_name, "mirror") ||
                   g_str_has_prefix (arg_name, "raidz") ||
                   g_str_has_prefix (arg_name, "draid") ||
-                  g_str_has_prefix (arg_name, "spare")))
+                  g_str_has_prefix (arg_name, "spare") ||
+                  g_str_has_prefix (arg_name, "log")))
       valid = FALSE;
 
     if (!valid)
@@ -355,8 +360,9 @@ handle_pool_create (UDisksManagerZFS      *_manager,
                                                UDISKS_ERROR,
                                                UDISKS_ERROR_FAILED,
                                                "Invalid pool name '%s': must start with a letter, "
-                                               "contain only [a-zA-Z0-9_-.], and not use reserved "
-                                               "prefixes (mirror, raidz, draid, spare)",
+                                               "contain only [a-zA-Z0-9_-.:], be at most 239 "
+                                               "characters, and not use reserved prefixes "
+                                               "(mirror, raidz, draid, spare, log)",
                                                arg_name);
         goto out;
       }
@@ -366,6 +372,11 @@ handle_pool_create (UDisksManagerZFS      *_manager,
   device_paths = resolve_blocks_to_device_paths (daemon, arg_blocks, invocation, NULL);
   if (device_paths == NULL)
     goto out;
+
+  /* Normalize empty vdev_type to NULL (stripe).  libblockdev treats
+   * non-NULL as a real argv token, so "" would be a bogus raid level. */
+  if (arg_vdev_type != NULL && arg_vdev_type[0] == '\0')
+    arg_vdev_type = NULL;
 
   /* Create the pool */
   if (!bd_zfs_pool_create (arg_name,

--- a/modules/zfs/udiskslinuxpoolobjectzfs.c
+++ b/modules/zfs/udiskslinuxpoolobjectzfs.c
@@ -390,6 +390,11 @@ handle_add_vdev (UDisksZFSPool         *iface,
   if (device_paths == NULL)
     goto out;
 
+  /* Normalize empty vdev_type to NULL (stripe).  libblockdev treats
+   * non-NULL as a real argv token, so "" would be a bogus raid level. */
+  if (arg_vdev_type != NULL && arg_vdev_type[0] == '\0')
+    arg_vdev_type = NULL;
+
   if (!bd_zfs_pool_add_vdev (object->name,
                              (const gchar **) device_paths,
                              arg_vdev_type,
@@ -1599,6 +1604,20 @@ handle_load_key (UDisksZFSPool         *iface,
     }
   else if (g_variant_lookup (arg_options, "key_location", "&s", &key_location))
     {
+      /* Validate key_location: only "prompt", "file://..." and "pkcs11:..."
+       * are legitimate ZFS key location schemes. */
+      if (g_strcmp0 (key_location, "prompt") != 0 &&
+          !g_str_has_prefix (key_location, "file://") &&
+          !g_str_has_prefix (key_location, "pkcs11:"))
+        {
+          g_dbus_method_invocation_return_error (invocation,
+                                                 UDISKS_ERROR,
+                                                 UDISKS_ERROR_FAILED,
+                                                 "Invalid key_location '%s': must be 'prompt', "
+                                                 "'file://...' or 'pkcs11:...'",
+                                                 key_location);
+          goto out;
+        }
       success = bd_zfs_encryption_load_key (arg_dataset, key_location, &error);
     }
   else
@@ -1689,6 +1708,21 @@ handle_change_key (UDisksZFSPool         *iface,
                                      invocation);
 
   g_variant_lookup (arg_options, "new_key_location", "&s", &new_key_location);
+
+  /* Validate new_key_location if provided */
+  if (new_key_location != NULL &&
+      g_strcmp0 (new_key_location, "prompt") != 0 &&
+      !g_str_has_prefix (new_key_location, "file://") &&
+      !g_str_has_prefix (new_key_location, "pkcs11:"))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             UDISKS_ERROR,
+                                             UDISKS_ERROR_FAILED,
+                                             "Invalid new_key_location '%s': must be 'prompt', "
+                                             "'file://...' or 'pkcs11:...'",
+                                             new_key_location);
+      goto out;
+    }
 
   if (!bd_zfs_encryption_change_key (arg_dataset, new_key_location, NULL, &error))
     {

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -16,6 +16,9 @@ modules/lvm2/udiskslinuxmanagerlvm2.c
 modules/lvm2/udiskslinuxphysicalvolume.c
 modules/lvm2/udiskslinuxvdovolume.c
 modules/lvm2/udiskslinuxvolumegroup.c
+modules/zfs/data/org.freedesktop.UDisks2.zfs.policy.in
+modules/zfs/udiskslinuxmanagerzfs.c
+modules/zfs/udiskslinuxpoolobjectzfs.c
 src/udisksbasejob.c
 src/udisksdaemonutil.c
 src/udiskslinuxblock.c


### PR DESCRIPTION
## Summary

- **POTFILES.in**: Added ZFS policy file + source files with translatable strings
- **Gettext includes**: Fixed gi18n.h -> gi18n-lib.h in block/filesystem ZFS modules
- **Encryption key-location**: LoadKey/ChangeKey now reject arbitrary key locations; only prompt, file://, pkcs11: accepted
- **Stripe normalization**: Empty string vdev_type normalized to NULL in PoolCreate and AddVdev
- **Pool-name validation**: Added colon to allowed chars, 239-char limit, log to reserved prefixes

Closes d3vi1/udisks#29