### PR TITLE
Fix RollbackSnapshot: map force to force-unmount, add destroy_newer option

### DIFF
--- a/modules/zfs/data/org.freedesktop.UDisks2.zfs.xml
+++ b/modules/zfs/data/org.freedesktop.UDisks2.zfs.xml
@@ -466,6 +466,24 @@
         @options: Additional options.
 
         Rolls back to a ZFS snapshot.
+
+        Known options:
+          <variablelist>
+            <varlistentry>
+              <term>force (type 'b')</term>
+              <listitem><para>
+                If %TRUE, force-unmount any affected file systems (zfs rollback -f).
+                Defaults to %FALSE.
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>destroy_newer (type 'b')</term>
+              <listitem><para>
+                If %TRUE, destroy snapshots and bookmarks more recent than the
+                target (zfs rollback -r).  Defaults to %FALSE.
+              </para></listitem>
+            </varlistentry>
+          </variablelist>
     -->
     <method name="RollbackSnapshot">
       <arg name="name" direction="in" type="s"/>

--- a/modules/zfs/udiskslinuxpoolobjectzfs.c
+++ b/modules/zfs/udiskslinuxpoolobjectzfs.c
@@ -1356,6 +1356,7 @@ handle_rollback_snapshot (UDisksZFSPool         *iface,
   UDisksDaemon *daemon;
   GError *error = NULL;
   gboolean force = FALSE;
+  gboolean destroy_newer = FALSE;
 
   daemon = udisks_module_get_daemon (UDISKS_MODULE (object->module));
 
@@ -1376,12 +1377,18 @@ handle_rollback_snapshot (UDisksZFSPool         *iface,
                                      invocation);
 
   /* Honor the caller's "force" option.  When force=TRUE, dependent
-   * file systems and clones that would be destroyed by the rollback
-   * are force-unmounted.  The default (force=FALSE) causes the
+   * file systems that would be affected by the rollback are
+   * force-unmounted (-f).  The default (force=FALSE) causes the
    * operation to fail if any dependent dataset is in use. */
   g_variant_lookup (arg_options, "force", "b", &force);
 
-  if (!bd_zfs_snapshot_rollback (arg_name, FALSE, force, &error))
+  /* Honor the caller's "destroy_newer" option.  When
+   * destroy_newer=TRUE, snapshots and bookmarks more recent than the
+   * target are destroyed (-r).  The default (destroy_newer=FALSE)
+   * causes the operation to fail if newer snapshots exist. */
+  g_variant_lookup (arg_options, "destroy_newer", "b", &destroy_newer);
+
+  if (!bd_zfs_snapshot_rollback (arg_name, force, destroy_newer, &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;

--- a/src/tests/dbus-tests/test_zfs.py
+++ b/src/tests/dbus-tests/test_zfs.py
@@ -54,6 +54,22 @@ class UDisksZFSTest(udiskstestcase.UdisksTestCase):
         """Test scrub progress polling"""
         self.skipTest("Scrub test requires an active ZFS pool")
 
+    def test_rollback_snapshot_default_options(self):
+        """Test RollbackSnapshot accepts default options (no force, no destroy_newer)"""
+        self.skipTest("Rollback test requires an active ZFS pool with snapshots")
+
+    def test_rollback_snapshot_force_option(self):
+        """Test RollbackSnapshot passes force option as force-unmount (-f)"""
+        self.skipTest("Rollback test requires an active ZFS pool with snapshots")
+
+    def test_rollback_snapshot_destroy_newer_option(self):
+        """Test RollbackSnapshot passes destroy_newer option to destroy newer snapshots (-r)"""
+        self.skipTest("Rollback test requires an active ZFS pool with snapshots")
+
+    def test_rollback_snapshot_both_options(self):
+        """Test RollbackSnapshot with both force and destroy_newer options"""
+        self.skipTest("Rollback test requires an active ZFS pool with snapshots")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Fix parameter swap: `force` now correctly maps to libblockdev's force-unmount (`-f`), not destroy_newer (`-r`)
- Add new `destroy_newer` D-Bus option for explicit newer-snapshot destruction
- Update D-Bus XML docs to describe both options

Closes #31

## Test plan
- [x] Test stubs for all 4 parameter combinations (default, force-only, destroy_newer-only, both)
- [x] Verified parameter order matches libblockdev API signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)