### PR TITLE
Fix PoolImportAll: replace shellout with per-pool libblockdev imports, honor force

### DIFF
--- a/modules/zfs/data/org.freedesktop.UDisks2.zfs.xml
+++ b/modules/zfs/data/org.freedesktop.UDisks2.zfs.xml
@@ -93,7 +93,23 @@
         PoolImportAll:
         @options: Additional options.
 
-        Imports all available ZFS pools.
+        Imports all available ZFS pools.  Internally enumerates
+        importable pools and imports each one individually via
+        libblockdev, providing per-pool error reporting.  If any
+        individual imports fail, the error message lists each failed
+        pool and its reason.
+
+        Known options:
+          <variablelist>
+            <varlistentry>
+              <term>force (type 'b')</term>
+              <listitem><para>
+                If %TRUE, force import of each pool even if it was
+                previously in use (equivalent to zpool import -f -a).
+                Defaults to %FALSE.
+              </para></listitem>
+            </varlistentry>
+          </variablelist>
     -->
     <method name="PoolImportAll">
       <arg name="options" direction="in" type="a{sv}"/>

--- a/modules/zfs/udiskslinuxmanagerzfs.c
+++ b/modules/zfs/udiskslinuxmanagerzfs.c
@@ -23,7 +23,6 @@
 #include <string.h>
 
 #include <blockdev/zfs.h>
-#include <blockdev/utils.h>
 
 #include <src/udisksdaemon.h>
 #include <src/udisksdaemonutil.h>
@@ -601,13 +600,20 @@ handle_pool_import_all (UDisksManagerZFS      *_manager,
   UDisksLinuxManagerZFS *manager = UDISKS_LINUX_MANAGER_ZFS (_manager);
   UDisksDaemon *daemon;
   GError *error = NULL;
-  const gchar *argv[] = { "zpool", "import", "-a", NULL };
+  BDZFSPoolInfo **importable = NULL;
+  BDZFSPoolInfo **p;
+  gboolean force = FALSE;
+  GString *errors_str = NULL;
+  guint n_failed = 0;
 
   daemon = udisks_module_get_daemon (UDISKS_MODULE (manager->module));
 
+  g_variant_lookup (arg_options, "force", "b", &force);
+
   /* Bulk-importing every available pool is a higher-privilege operation
    * than importing a single named pool: it can activate pools the admin
-   * did not intend to bring online.  Use the destroy (auth_admin) tier. */
+   * did not intend to bring online.  Always require the destroy
+   * (auth_admin) tier regardless of force. */
   UDISKS_DAEMON_CHECK_AUTHORIZATION (daemon,
                                      NULL,
                                      ZFS_POLICY_ACTION_ID_DESTROY,
@@ -615,12 +621,59 @@ handle_pool_import_all (UDisksManagerZFS      *_manager,
                                      N_("Authentication is required to import all ZFS pools"),
                                      invocation);
 
-  /* There is no single libblockdev call for "import all"; invoke zpool
-   * directly.  bd_utils_exec_and_report_error runs the command
-   * synchronously and populates @error on failure. */
-  if (!bd_utils_exec_and_report_error (argv, NULL, &error))
+  /* Enumerate importable pools via libblockdev rather than shelling out
+   * to "zpool import -a" directly.  This uses the same code path as
+   * ListImportablePools and gives us per-pool error reporting. */
+  importable = bd_zfs_pool_list_importable (&error);
+  if (importable == NULL && error != NULL)
     {
       g_dbus_method_invocation_take_error (invocation, error);
+      goto out;
+    }
+
+  /* Import each pool individually via bd_zfs_pool_import(), honoring
+   * the force option and collecting per-pool errors. */
+  if (importable != NULL)
+    {
+      for (p = importable; *p != NULL; p++)
+        {
+          BDZFSPoolInfo *info = *p;
+          GError *pool_error = NULL;
+
+          if (info->name == NULL || info->name[0] == '\0')
+            continue;
+
+          if (!bd_zfs_pool_import (info->name,
+                                   NULL,         /* new_name */
+                                   NULL,         /* search_dirs */
+                                   force,
+                                   NULL,         /* extra args */
+                                   &pool_error))
+            {
+              if (errors_str == NULL)
+                errors_str = g_string_new (NULL);
+              else
+                g_string_append (errors_str, "; ");
+
+              g_string_append_printf (errors_str, "%s: %s",
+                                      info->name,
+                                      pool_error->message);
+              g_error_free (pool_error);
+              n_failed++;
+            }
+        }
+    }
+
+  /* If any individual imports failed, report a combined error */
+  if (n_failed > 0)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             UDISKS_ERROR,
+                                             UDISKS_ERROR_FAILED,
+                                             "Failed to import %u pool(s): %s",
+                                             n_failed,
+                                             errors_str->str);
+      g_string_free (errors_str, TRUE);
       goto out;
     }
 
@@ -630,6 +683,12 @@ handle_pool_import_all (UDisksManagerZFS      *_manager,
   udisks_manager_zfs_complete_pool_import_all (_manager, invocation);
 
  out:
+  if (importable != NULL)
+    {
+      for (p = importable; *p != NULL; p++)
+        bd_zfs_pool_info_free (*p);
+      g_free (importable);
+    }
   return TRUE;
 }
 

--- a/src/tests/dbus-tests/test_zfs.py
+++ b/src/tests/dbus-tests/test_zfs.py
@@ -86,6 +86,22 @@ class UDisksZFSTest(udiskstestcase.UdisksTestCase):
         """Test PoolImport by GUID with new_name option"""
         self.skipTest("Import-by-GUID-with-new_name test requires an exported ZFS pool")
 
+    def test_pool_import_all_default(self):
+        """Test PoolImportAll imports all available pools without force"""
+        self.skipTest("PoolImportAll test requires exported ZFS pools")
+
+    def test_pool_import_all_force(self):
+        """Test PoolImportAll with force=True passes -f to each pool import"""
+        self.skipTest("PoolImportAll test requires exported ZFS pools")
+
+    def test_pool_import_all_no_pools(self):
+        """Test PoolImportAll succeeds gracefully when no pools are importable"""
+        self.skipTest("PoolImportAll test requires no exported ZFS pools present")
+
+    def test_pool_import_all_partial_failure(self):
+        """Test PoolImportAll reports per-pool errors when some imports fail"""
+        self.skipTest("PoolImportAll partial-failure test requires multiple exported ZFS pools")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Replace raw `zpool import -a` shellout with `bd_zfs_pool_list_importable()` + per-pool `bd_zfs_pool_import()`
- Honor `force` option from D-Bus options dictionary
- Collect per-pool errors into combined error message
- Remove unused `blockdev/utils.h` include
- Update D-Bus XML docs

Closes #35

## Test plan
- [x] 4 test stubs for default, force, no-pools, partial-failure
- [x] API signatures verified against libblockdev headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)