### PR TITLE
Fix InheritProperty: reject pool-only properties at D-Bus boundary

### DIFF
--- a/modules/zfs/udiskslinuxpoolobjectzfs.c
+++ b/modules/zfs/udiskslinuxpoolobjectzfs.c
@@ -2399,6 +2399,20 @@ handle_inherit_property (UDisksZFSPool         *iface,
       goto out;
     }
 
+  /* Reject pool-only properties — they are valid on pool objects but
+   * meaningless on datasets; give a clear error rather than letting
+   * ZFS fail with a confusing message. */
+  if (udisks_zfs_property_is_pool_only (arg_property))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             UDISKS_ERROR,
+                                             UDISKS_ERROR_OPTION_NOT_PERMITTED,
+                                             "Property '%s' is a pool-level property and "
+                                             "cannot be inherited on a dataset",
+                                             arg_property);
+      goto out;
+    }
+
   /* Check property against the allowlist */
   if (!udisks_zfs_property_is_allowed (arg_property, &prop_error))
     {

--- a/src/tests/dbus-tests/test_zfs.py
+++ b/src/tests/dbus-tests/test_zfs.py
@@ -118,6 +118,14 @@ class UDisksZFSTest(udiskstestcase.UdisksTestCase):
         """Test MountDataset rejects options containing newlines or tabs"""
         self.skipTest("Mount malformed-options test requires an active ZFS pool with datasets")
 
+    def test_inherit_property_rejects_pool_only(self):
+        """Test InheritProperty rejects pool-only properties like autoexpand"""
+        self.skipTest("InheritProperty pool-only rejection test requires an active ZFS pool")
+
+    def test_inherit_property_allows_dataset_property(self):
+        """Test InheritProperty accepts dataset-level properties like compression"""
+        self.skipTest("InheritProperty dataset-property test requires an active ZFS pool")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `udisks_zfs_property_is_pool_only()` check in `handle_inherit_property`
- Uses same error pattern as `handle_set_dataset_property`
- Pool-only properties (autoexpand, comment, multihost, etc.) now rejected before backend call

Closes #41

## Test plan
- [x] 2 test stubs: rejection of pool-only property, acceptance of dataset property

🤖 Generated with [Claude Code](https://claude.com/claude-code)