### PR TITLE
Fix ListDatasets: map unrecognized types/key states to "unknown" instead of defaults

### DIFF
--- a/modules/zfs/data/org.freedesktop.UDisks2.zfs.xml
+++ b/modules/zfs/data/org.freedesktop.UDisks2.zfs.xml
@@ -436,6 +436,65 @@
         @datasets: An array of dictionaries with dataset properties.
 
         Lists all datasets in the pool.
+
+        Each dictionary in @datasets contains:
+          <variablelist>
+            <varlistentry>
+              <term>name (type 's')</term>
+              <listitem><para>
+                Full dataset name (e.g. <literal>pool/child</literal>).
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>type (type 's')</term>
+              <listitem><para>
+                One of <literal>"filesystem"</literal>,
+                <literal>"volume"</literal>,
+                <literal>"snapshot"</literal>,
+                <literal>"bookmark"</literal>, or
+                <literal>"unknown"</literal>.
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>key-status (type 's')</term>
+              <listitem><para>
+                One of <literal>"none"</literal>,
+                <literal>"available"</literal>,
+                <literal>"unavailable"</literal>, or
+                <literal>"unknown"</literal>.
+              </para></listitem>
+            </varlistentry>
+          </variablelist>
+
+        Known options:
+          <variablelist>
+            <varlistentry>
+              <term>recursive (type 'b')</term>
+              <listitem><para>
+                If %TRUE (the default), list datasets recursively.
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>type (type 's')</term>
+              <listitem><para>
+                Filter by dataset type.  Pass <literal>"all"</literal>
+                or omit to return every type.
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>offset (type 'x')</term>
+              <listitem><para>
+                Number of datasets to skip (default 0).
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>limit (type 'x')</term>
+              <listitem><para>
+                Maximum number of datasets to return (-1 for unlimited,
+                the default).
+              </para></listitem>
+            </varlistentry>
+          </variablelist>
     -->
     <method name="ListDatasets">
       <arg name="options" direction="in" type="a{sv}"/>

--- a/modules/zfs/udiskslinuxpoolobjectzfs.c
+++ b/modules/zfs/udiskslinuxpoolobjectzfs.c
@@ -1092,10 +1092,13 @@ handle_list_datasets (UDisksZFSPool         *iface,
         {
           BDZFSDatasetInfo *info = *p;
           GVariantBuilder dict_builder;
-          const gchar *type_str = "filesystem";
+          const gchar *type_str;
 
           switch (info->type)
             {
+            case BD_ZFS_DATASET_TYPE_FILESYSTEM:
+              type_str = "filesystem";
+              break;
             case BD_ZFS_DATASET_TYPE_VOLUME:
               type_str = "volume";
               break;
@@ -1106,6 +1109,7 @@ handle_list_datasets (UDisksZFSPool         *iface,
               type_str = "bookmark";
               break;
             default:
+              type_str = "unknown";
               break;
             }
 
@@ -1156,11 +1160,15 @@ handle_list_datasets (UDisksZFSPool         *iface,
                                    g_variant_new_string (info->origin));
 
           {
-            const gchar *ks = "none";
-            if (info->key_status == BD_ZFS_KEY_STATUS_AVAILABLE)
+            const gchar *ks;
+            if (info->key_status == BD_ZFS_KEY_STATUS_NONE)
+              ks = "none";
+            else if (info->key_status == BD_ZFS_KEY_STATUS_AVAILABLE)
               ks = "available";
             else if (info->key_status == BD_ZFS_KEY_STATUS_UNAVAILABLE)
               ks = "unavailable";
+            else
+              ks = "unknown";
             g_variant_builder_add (&dict_builder, "{sv}", "key-status",
                                    g_variant_new_string (ks));
           }

--- a/src/tests/dbus-tests/test_zfs.py
+++ b/src/tests/dbus-tests/test_zfs.py
@@ -118,6 +118,14 @@ class UDisksZFSTest(udiskstestcase.UdisksTestCase):
         """Test MountDataset rejects options containing newlines or tabs"""
         self.skipTest("Mount malformed-options test requires an active ZFS pool with datasets")
 
+    def test_list_datasets_unknown_type(self):
+        """Test ListDatasets maps unrecognized backend dataset types to 'unknown'"""
+        self.skipTest("Unknown-type mapping test requires a ZFS pool with a non-standard dataset type")
+
+    def test_list_datasets_unknown_key_status(self):
+        """Test ListDatasets maps unrecognized backend key states to 'unknown'"""
+        self.skipTest("Unknown-key-status mapping test requires a ZFS pool with a non-standard key state")
+
     def test_inherit_property_rejects_pool_only(self):
         """Test InheritProperty rejects pool-only properties like autoexpand"""
         self.skipTest("InheritProperty pool-only rejection test requires an active ZFS pool")


### PR DESCRIPTION
## Summary
- Unknown dataset types now map to \"unknown\" instead of \"filesystem\"
- Unknown key states now map to \"unknown\" instead of \"none\"
- D-Bus XML docs updated with all possible values
- Prevents silent misclassification of new backend enum variants

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)