### PR TITLE
Fix MountDataset: reject caller mount options until real policy engine integration

### DIFF
--- a/modules/zfs/data/org.freedesktop.UDisks2.zfs.xml
+++ b/modules/zfs/data/org.freedesktop.UDisks2.zfs.xml
@@ -551,20 +551,14 @@
         @name: The dataset name to mount.
         @options: Additional options.
 
-        Mounts a ZFS dataset.  The safety defaults
-        <literal>nosuid,nodev</literal> are always prepended to the
-        mount options, matching the core UDisks mount policy.
+        Mounts a ZFS dataset.  The hardcoded mount options
+        <literal>nosuid,nodev</literal> are always applied.
+        Caller-supplied mount options are not supported because the
+        ZFS module does not implement the full UDisks mount-option
+        allow/deny policy (see <literal>udiskslinuxmountoptions.c</literal>).
 
         Known options:
           <variablelist>
-            <varlistentry>
-              <term>mount_options (type 's')</term>
-              <listitem><para>
-                Comma-separated mount options to append after the
-                mandatory <literal>nosuid,nodev</literal> defaults.
-                Options containing newlines or tabs are rejected.
-              </para></listitem>
-            </varlistentry>
             <varlistentry>
               <term>mountpoint (type 's')</term>
               <listitem><para>

--- a/modules/zfs/udiskslinuxpoolobjectzfs.c
+++ b/modules/zfs/udiskslinuxpoolobjectzfs.c
@@ -1286,9 +1286,7 @@ handle_mount_dataset (UDisksZFSPool         *iface,
   UDisksLinuxPoolObjectZFS *object = UDISKS_LINUX_POOL_OBJECT_ZFS (user_data);
   UDisksDaemon *daemon;
   GError *error = NULL;
-  const gchar *caller_mount_options = NULL;
   const gchar *mountpoint = NULL;
-  gchar *effective_options = NULL;
   BDExtraArg *extra[2] = {NULL, NULL};
 
   daemon = udisks_module_get_daemon (UDISKS_MODULE (object->module));
@@ -1308,33 +1306,13 @@ handle_mount_dataset (UDisksZFSPool         *iface,
                                      N_("Authentication is required to mount a ZFS dataset"),
                                      invocation);
 
-  /* Extract optional caller-provided mount options and mountpoint */
-  g_variant_lookup (arg_options, "mount_options", "&s", &caller_mount_options);
+  /* Extract optional mountpoint override */
   g_variant_lookup (arg_options, "mountpoint", "&s", &mountpoint);
 
-  /* Enforce nosuid,nodev safety defaults, matching the core UDisks mount
-   * policy (see udiskslinuxmountoptions.c).  Caller-supplied options are
-   * appended after the mandatory defaults so they cannot override them. */
-  if (caller_mount_options != NULL && *caller_mount_options != '\0')
-    {
-      /* Reject mount options that contain embedded newlines or tabs;
-       * these could confuse /proc/mounts parsing. */
-      if (strpbrk (caller_mount_options, "\n\t") != NULL)
-        {
-          g_dbus_method_invocation_return_error (invocation,
-                                                 UDISKS_ERROR,
-                                                 UDISKS_ERROR_OPTION_NOT_PERMITTED,
-                                                 "Malformed mount option string");
-          goto out;
-        }
-      effective_options = g_strdup_printf ("nosuid,nodev,%s", caller_mount_options);
-    }
-  else
-    {
-      effective_options = g_strdup ("nosuid,nodev");
-    }
-
-  extra[0] = bd_extra_arg_new ("-o", effective_options);
+  /* Hardcoded safety defaults -- caller-supplied mount options are not
+   * supported because the ZFS module does not implement the full UDisks
+   * mount-option allow/deny policy (see udiskslinuxmountoptions.c). */
+  extra[0] = bd_extra_arg_new ("-o", "nosuid,nodev");
 
   if (!bd_zfs_dataset_mount (arg_name, mountpoint,
                              (const BDExtraArg **) extra, &error))
@@ -1348,7 +1326,6 @@ handle_mount_dataset (UDisksZFSPool         *iface,
 
  out:
   bd_extra_arg_free (extra[0]);
-  g_free (effective_options);
   return TRUE;
 }
 


### PR DESCRIPTION
## Summary
- Remove caller mount_options support (no full UDisks allow/deny policy exists)
- Only hardcoded nosuid,nodev defaults applied
- Mountpoint option kept
- XML no longer falsely claims core UDisks mount policy compliance

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)